### PR TITLE
Some fixes in the logic that triggers the translation request

### DIFF
--- a/priv/static/builder/events/git_push.ts
+++ b/priv/static/builder/events/git_push.ts
@@ -21,7 +21,7 @@ export default async function gitPush() {
   );
   console.info("Translation payload generated", payload);
   console.info("Creating translation");
-  await glossiaFetch("/api/translations", {
+  await glossiaFetch("/api/translation-requests", {
     method: "POST",
     body: JSON.stringify(payload),
     headers: {

--- a/priv/static/builder/events/git_push.ts
+++ b/priv/static/builder/events/git_push.ts
@@ -21,7 +21,7 @@ export default async function gitPush() {
   );
   console.info("Translation payload generated", payload);
   console.info("Creating translation");
-  await glossiaFetch("/builder/api/translations", {
+  await glossiaFetch("/api/translations", {
     method: "POST",
     body: JSON.stringify(payload),
     headers: {

--- a/priv/static/builder/utils/http.ts
+++ b/priv/static/builder/utils/http.ts
@@ -16,7 +16,13 @@ export async function glossiaFetch<T>(
       "authorization": `Bearer ${getAccessToken()}`,
     },
   });
-  const jsonData = await jsonResponse.json();
+  let jsonData;
+  try {
+    jsonData = await jsonResponse.json();
+  } catch (error) {
+    console.error("Error parsing JSON response from Glossia", error);
+    throw error;
+  }
   console.info("Glossia responded", {
     status: jsonResponse.status,
     body: jsonData,

--- a/priv/static/builder/utils/vcs/types.ts
+++ b/priv/static/builder/utils/vcs/types.ts
@@ -11,7 +11,8 @@ export type FileFormat =
   | "yaml"
   | "json"
   | "toml"
-  | "portable-object";
+  | "portable-object"
+  | "portable-object-template";
 
 export type TranslationRequestPayload = {
   id: string;

--- a/priv/static/builder/utils/vcs/utilities.ts
+++ b/priv/static/builder/utils/vcs/utilities.ts
@@ -27,6 +27,8 @@ export function getFileFormat(
       return "toml";
     case "po":
       return "portable-object";
+    case "pot":
+      return "portable-object-template";
     default:
       return undefined;
   }


### PR DESCRIPTION
- Update the endpoint we hit from `/builder/api/*` to just `/api`
- `console.error` errors from JSON.parsing the output coming from our API.
- Include `portable-object-template` as a supported format.