### PR TITLE
Handle not founds in the API

### DIFF
--- a/lib/glossia_web/controllers/api/api_controller.ex
+++ b/lib/glossia_web/controllers/api/api_controller.ex
@@ -1,0 +1,8 @@
+defmodule GlossiaWeb.API.APIController do
+  # Modules
+  use GlossiaWeb, :controller
+
+  def not_found(%{ request_path: request_path, method: method } = conn, _params) do
+    conn |> put_status(:not_found) |> json(%{errors: [%{detail: "#{method} #{request_path} is an invalid resource"}]})
+  end
+end

--- a/lib/glossia_web/controllers/api/localization_request_controller.ex
+++ b/lib/glossia_web/controllers/api/localization_request_controller.ex
@@ -3,7 +3,7 @@ defmodule GlossiaWeb.API.LocalizationRequestController do
   use GlossiaWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
-  tags ["localization-requesets"]
+  tags ["localization-requests"]
 
   alias GlossiaWeb.OpenAPI.Schemas.LocalizationRequest.{
     CreateResponse,
@@ -20,7 +20,7 @@ defmodule GlossiaWeb.API.LocalizationRequestController do
     ]
 
   def create(conn, _params) do
-    GlossiaWeb.Auth.Policies.enforce!(conn, {:create, :localization_request})
+    GlossiaWeb.Auth.Policies.enforce!(conn, {:create, :translation_request})
     json(conn, %{"hello" => "yay"})
   end
 end

--- a/lib/glossia_web/router.ex
+++ b/lib/glossia_web/router.ex
@@ -76,7 +76,8 @@ defmodule GlossiaWeb.Router do
     get "/changelog", MarketingController, :changelog
   end
 
-  # API
+  # Authenticated API endpoints:
+  # These endpoints authenticate and authorize the authenticated entities
   scope "/api", GlossiaWeb.API do
     pipe_through [:api, :auth_api]
 
@@ -84,10 +85,14 @@ defmodule GlossiaWeb.Router do
       only: [:create]
   end
 
+  # Unauthenticated API endpoints:
+  # There are some endpoints, like the one that returns the OpenAPI spec, that don't
+  # require being authenticated because they don't return resource-tied data.
   scope "/api" do
     pipe_through [:api]
 
     get "/openapi", OpenApiSpex.Plug.RenderSpec, []
+    match(:*, "/*path", GlossiaWeb.API.APIController, :not_found)
   end
 
   # RSS

--- a/test/glossia_web/controllers/api/api_controller_test.exs
+++ b/test/glossia_web/controllers/api/api_controller_test.exs
@@ -1,0 +1,12 @@
+defmodule GlossiaWeb.API.APIControllerTest do
+  use GlossiaWeb.ConnCase
+
+  test "not_found", %{ conn: conn } do
+    # Given/When
+    conn = get(conn, ~p"/api/invalid")
+
+    # Then
+    assert %{"errors" => [%{"detail" => "GET /api/invalid is an invalid resource"}]} =
+      json_response(conn, 404)
+  end
+end


### PR DESCRIPTION
I noticed that we were not handling not founds in the API endpoints because the builder logic was pointing to an invalid endpoint. To fix it, I'm adding a catch-all logic for all the `/api/*` routes for any HTTP method that returns a standard error with a 404 status code.