### PR TITLE
Include absent languages in the payload that we send to the server to initiate the localization request

### DIFF
--- a/priv/static/builder/utils/vcs/__snapshots__/localization_request_test.ts.snap
+++ b/priv/static/builder/utils/vcs/__snapshots__/localization_request_test.ts.snap
@@ -56,6 +56,15 @@ snapshot[`generateLocalizationRequestPayload with Glossia's configuration 1`] = 
             },
             id: "priv/gettext/es/LC_MESSAGES/default.po",
           },
+          {
+            checksum: {
+              cache_id: "priv/gettext/fr/LC_MESSAGES/.glossia.default.po.json",
+            },
+            context: {
+              language: "fr",
+            },
+            id: "priv/gettext/fr/LC_MESSAGES/default.po",
+          },
         ],
       },
     },

--- a/priv/static/builder/utils/vcs/file_tree.ts
+++ b/priv/static/builder/utils/vcs/file_tree.ts
@@ -42,11 +42,75 @@ export async function generateModulesPayload(
     manifestDirectory: dirname(configurationManifest.path),
     parentTree: {},
   });
-  return getPayloadFromTree(tree, {
+  let modules = await getPayloadFromTree(tree, {
     rootDirectory: options.rootDirectory,
     sourceContext: configurationManifest.context.source,
     manifestDirectory: dirname(configurationManifest.path),
   });
+  modules = await payloadAddingAbsentLocalizableTargets(modules, {
+    configurationManifest,
+  });
+
+  return modules;
+}
+
+type PayloadAddingAbsentLocalizableTargetsOptions = {
+  configurationManifest: ConfigurationManifest;
+};
+
+/**
+ * When we resolve the tree and flatten it, we do it using the file-system as the source of truth. As a consequence,
+ * target languages that haven't been added to the file system yet won't be present in the payload.
+ * This function ensures those files are present and includes them in the payload. That way, the server will see
+ * that they need to be translated
+ * @param modules {LocalizationRequestPayloadModule[]} The modules to add the absent localizable targets to.
+ * @param options {PayloadAddingAbsentLocalizableTargetsOptions} The options necessary to add the absent localizable targets.
+ * @returns {LocalizationRequestPayloadModule[]} The modules with the absent localizable targets added.
+ */
+function payloadAddingAbsentLocalizableTargets(
+  modules: LocalizationRequestPayloadModule[],
+  options: PayloadAddingAbsentLocalizableTargetsOptions,
+): LocalizationRequestPayloadModule[] {
+  return modules.map((module) => {
+    const id = module.id;
+    for (const context of options.configurationManifest.context.target) {
+      let path = id;
+      for (const contextAttribute of Object.entries(context)) {
+        path = path.replace(
+          `{${contextAttribute[0]}}`,
+          contextAttribute[1],
+        );
+      }
+      if (module.localizables.target.find((target) => target.id === path)) {
+        continue;
+      }
+      module = {
+        ...module,
+        localizables: {
+          ...module.localizables,
+          target: [
+            ...module.localizables.target,
+            {
+              id: path,
+              context: context,
+              checksum: {
+                cache_id: getChecksumJSONPathFromRelativePath(path),
+              },
+            },
+          ],
+        },
+      };
+      return module;
+    }
+    return module;
+  });
+}
+
+function getChecksumJSONPathFromRelativePath(path: string) {
+  return join(
+    dirname(path),
+    `.glossia.${basename(path)}.json`,
+  );
 }
 
 async function getPayloadFromTree(
@@ -92,10 +156,7 @@ async function getPayloadFromTree(
 
       for (const path of node.children) {
         const context = getContextFromFilePath(path, pathWithPlaceholders);
-        const checksumRelativePath = join(
-          dirname(path),
-          `.glossia.${basename(path)}.json`,
-        );
+        const checksumRelativePath = getChecksumJSONPathFromRelativePath(path);
         const checksumPath = join(manifestDirectory, checksumRelativePath);
         let cachedChecksum:
           | {

--- a/priv/static/builder/utils/vcs/localization_request_test.ts
+++ b/priv/static/builder/utils/vcs/localization_request_test.ts
@@ -37,7 +37,7 @@ Deno.test("generateLocalizationRequestPayload with Glossia's configuration", asy
       path: join(temporaryDirectory, "priv/glossia.jsonc"),
       context: {
         source: { language: "en", description: "This is a test content" },
-        target: [{ language: "es" }],
+        target: [{ language: "es" }, { language: "fr" }],
       },
       files: "gettext/{language}/LC_MESSAGES/*.po",
     }], {

--- a/priv/static/builder/utils/vcs/types.ts
+++ b/priv/static/builder/utils/vcs/types.ts
@@ -49,11 +49,11 @@ export type LocalizationRequestPayloadLocalizable<C extends Context> = {
   context: C;
   checksum: {
     cache_id: string;
-    content: {
+    content?: {
       current: LocalizationRequestPayloadLocalizableChecksum;
       cached?: LocalizationRequestPayloadLocalizableChecksum;
     };
-    context: {
+    context?: {
       current: LocalizationRequestPayloadLocalizableChecksum;
       cached?: LocalizationRequestPayloadLocalizableChecksum;
     };


### PR DESCRIPTION
While triggering some localization requests, I noticed I had forgotten to include in the payload the languages have been defined in the `glossia.jsonc` but that are not present yet in the file-system. This PR addresses that.