### PR TITLE
Rename `Glossia.VersionControl` to `Glossia.ContentSources`

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,4 +1,4 @@
-alias Glossia.{Accounts, Blog, Docs, Projects, Translations, VersionControl, Builds}
+alias Glossia.{Accounts, Blog, Docs, Projects, Translations, ContentSources, Builds}
 alias Glossia.Accounts.{Account, Organization, User}
 alias Glossia.Blog.{Post, Author}
 alias Glossia.Projects.{Project}

--- a/lib/glossia.ex
+++ b/lib/glossia.ex
@@ -9,7 +9,7 @@ defmodule Glossia do
       Auth,
       ErrorReporter,
       Blog,
-      VersionControl,
+      ContentSources,
       Accounts,
       Analytics,
       Projects,

--- a/lib/glossia/content_sources/content_source.ex
+++ b/lib/glossia/content_sources/content_source.ex
@@ -1,0 +1,14 @@
+defmodule Glossia.ContentSources.ContentSource do
+  @type version_t :: :latest | {:version, String.t()}
+
+  @doc """
+  It returns the content from a content source.
+
+  ## Parameters
+  - `content_id` - The content id. What it refers to depends on the content source. For example, in the case of a Git repository is the path to the file.
+  - `version` - The version of the content. It can be `:latest` or a specific version. In the case of content sources like GitHub, it represents the commit SHA when pulling a specific version.
+  - `project_id` - The project id. What it refers to depends on the content source. For example, in the case of a Git repository is the repository "owner/repository" identifier.
+  """
+  @callback get_content(content_id :: String.t(), version :: version_t, project_id :: String.t()) ::
+              {:ok, String.t()} | {:error, any()}
+end

--- a/lib/glossia/content_sources/github.ex
+++ b/lib/glossia/content_sources/github.ex
@@ -1,4 +1,4 @@
-defmodule Glossia.VersionControl.GitHub do
+defmodule Glossia.ContentSources.GitHub do
   @moduledoc """
   An interface to interact with GitHub's API.
   """
@@ -7,9 +7,9 @@ defmodule Glossia.VersionControl.GitHub do
   require Logger
 
   # Behaviors
-  @behaviour Glossia.VersionControl.Platform
+  @behaviour Glossia.ContentSources.Platform
 
-  # Glossia.VersionControl.Platform behavior
+  # Glossia.ContentSources.Platform behavior
 
   @impl true
   def get_file_content(path, repository_id) do
@@ -95,7 +95,7 @@ defmodule Glossia.VersionControl.GitHub do
 
   @impl true
   def generate_token_for_cloning(vcs_id) do
-    app_jwt_token = Glossia.VersionControl.GitHub.AppToken.generate_and_sign!()
+    app_jwt_token = Glossia.ContentSources.GitHub.AppToken.generate_and_sign!()
     client = Tentacat.Client.new(%{jwt: app_jwt_token})
 
     {200, %{"id" => installation_id}, _} =
@@ -120,7 +120,7 @@ defmodule Glossia.VersionControl.GitHub do
         ) ::
           Tentacat.Client.t()
   defp get_client_for_installation(installation_id, app_jwk_token) do
-    app_jwt_token = app_jwk_token || Glossia.VersionControl.GitHub.AppToken.generate_and_sign!()
+    app_jwt_token = app_jwk_token || Glossia.ContentSources.GitHub.AppToken.generate_and_sign!()
     client = Tentacat.Client.new(%{jwt: app_jwt_token})
 
     {201, %{"token" => access_token}, _} =
@@ -130,7 +130,7 @@ defmodule Glossia.VersionControl.GitHub do
   end
 
   defp get_client_for_repository(vcs_id) do
-    app_jwt_token = Glossia.VersionControl.GitHub.AppToken.generate_and_sign!()
+    app_jwt_token = Glossia.ContentSources.GitHub.AppToken.generate_and_sign!()
 
     {200, %{"id" => installation_id}, _} =
       Tentacat.get(

--- a/lib/glossia/content_sources/github/app_token.ex
+++ b/lib/glossia/content_sources/github/app_token.ex
@@ -1,4 +1,4 @@
-defmodule Glossia.VersionControl.GitHub.AppToken do
+defmodule Glossia.ContentSources.GitHub.AppToken do
   use Joken.Config, default_signer: :github
 
   def token_config do

--- a/lib/glossia/content_sources/platform.ex
+++ b/lib/glossia/content_sources/platform.ex
@@ -1,4 +1,4 @@
-defmodule Glossia.VersionControl.Platform do
+defmodule Glossia.ContentSources.Platform do
   # Types
 
   @type t :: :github
@@ -15,7 +15,7 @@ defmodule Glossia.VersionControl.Platform do
 
   ## Examples
 
-    iex > Glossia.VersionControl.Platform.get_file_content("glossia.jsonc", "glossia/glossia")
+    iex > Glossia.ContentSources.Platform.get_file_content("glossia.jsonc", "glossia/glossia")
     {:ok, "..."}
   """
   @callback get_file_content(

--- a/lib/glossia/events.ex
+++ b/lib/glossia/events.ex
@@ -1,5 +1,5 @@
 defmodule Glossia.Events do
-  use Boundary, deps: [Glossia.VersionControl, Glossia.Repo, Glossia.Builds], exports: [GitEvent]
+  use Boundary, deps: [Glossia.ContentSources, Glossia.Repo, Glossia.Builds], exports: [GitEvent]
 
   # Modules
   alias Glossia.Events.GitEventWorker

--- a/lib/glossia/events/git_event.ex
+++ b/lib/glossia/events/git_event.ex
@@ -7,7 +7,7 @@ defmodule Glossia.Events.GitEvent do
   @type t :: %__MODULE__{
           commit_sha: String.t(),
           vcs_id: String.t() | nil,
-          vcs_platform: Glossia.VersionControl.Platform.t(),
+          vcs_platform: Glossia.ContentSources.Platform.t(),
           vm_id: String.t() | nil,
           status: status(),
           project: Glossia.Projects.Project.t() | nil

--- a/lib/glossia/events/git_event_worker.ex
+++ b/lib/glossia/events/git_event_worker.ex
@@ -130,7 +130,7 @@ defmodule Glossia.Events.GitEventWorker do
     attrs
     |> Map.put_new(:target_url, "")
     |> Map.put_new(:context, context)
-    |> Glossia.VersionControl.create_commit_status()
+    |> Glossia.ContentSources.create_commit_status()
   end
 
   def get_commit_status_context_for_env(:prod) do

--- a/lib/glossia/localizations/api/schemas/localization_request.ex
+++ b/lib/glossia/localizations/api/schemas/localization_request.ex
@@ -1,5 +1,4 @@
 defmodule Glossia.Localizations.API.Schemas.LocalizationRequest do
-
   # Modules
   require OpenApiSpex
   alias OpenApiSpex.Schema

--- a/lib/glossia/projects.ex
+++ b/lib/glossia/projects.ex
@@ -1,5 +1,5 @@
 defmodule Glossia.Projects do
-  use Boundary, deps: [Glossia.Repo, Glossia.Events, Glossia.VersionControl], exports: [Project]
+  use Boundary, deps: [Glossia.Repo, Glossia.Events, Glossia.ContentSources], exports: [Project]
 
   @moduledoc """
   The projects context
@@ -56,7 +56,7 @@ defmodule Glossia.Projects do
       |> Map.put(:access_token, generate_token_for_project(project))
       |> Map.put(
         :git_access_token,
-        Glossia.VersionControl.generate_token_for_cloning(%{
+        Glossia.ContentSources.generate_token_for_cloning(%{
           vcs_id: project.vcs_id,
           vcs_platform: project.vcs_platform
         })

--- a/lib/glossia/projects.ex
+++ b/lib/glossia/projects.ex
@@ -41,6 +41,7 @@ defmodule Glossia.Projects do
       ) do
     default_branch = opts |> Map.fetch!(:default_branch)
     project = project |> Repo.preload(:account)
+
     :ok =
       %{
         event: event,

--- a/lib/glossia/projects/project.ex
+++ b/lib/glossia/projects/project.ex
@@ -13,7 +13,7 @@ defmodule Glossia.Projects.Project do
           type: type(),
           visibility: visibility(),
           vcs_id: String.t(),
-          vcs_platform: Glossia.VersionControl.t()
+          vcs_platform: Glossia.ContentSources.t()
         }
   @type visibility :: :public | :private
   @type type :: :git
@@ -48,7 +48,7 @@ defmodule Glossia.Projects.Project do
   @type changeset_attrs :: %{
           handle: String.t(),
           vcs_id: String.t(),
-          vcs_platform: Glossia.VersionControl.t(),
+          vcs_platform: Glossia.ContentSources.t(),
           account_id: integer()
         }
   @spec changeset(project :: t(), attrs :: changeset_attrs()) :: Ecto.Changeset.t()

--- a/lib/glossia/version_control.ex
+++ b/lib/glossia/version_control.ex
@@ -1,4 +1,4 @@
-defmodule Glossia.VersionControl do
+defmodule Glossia.ContentSources do
   @moduledoc """
   It provides a standard interface for interacting with version control platforms.
   """
@@ -9,23 +9,23 @@ defmodule Glossia.VersionControl do
   @spec is_webhook_payload_valid?(
           req_headers :: Keyword.t(),
           payload :: map(),
-          vcs :: Glossia.VersionControl.Platform.t()
+          vcs :: Glossia.ContentSources.Platform.t()
         ) :: boolean()
   def is_webhook_payload_valid?(req_headers, payload, vcs) do
     case vcs do
       :github ->
-        Glossia.VersionControl.GitHub.is_webhook_payload_valid?(req_headers, payload)
+        Glossia.ContentSources.GitHub.is_webhook_payload_valid?(req_headers, payload)
     end
   end
 
   @spec generate_token_for_cloning(%{
           vcs_id: String.t(),
-          vcs_platform: Glossia.VersionControl.Platform.t()
+          vcs_platform: Glossia.ContentSources.Platform.t()
         }) :: String.t()
   def generate_token_for_cloning(%{vcs_id: vcs_id, vcs_platform: vcs_platform}) do
     case vcs_platform do
       :github ->
-        Glossia.VersionControl.GitHub.generate_token_for_cloning(vcs_id)
+        Glossia.ContentSources.GitHub.generate_token_for_cloning(vcs_id)
     end
   end
 
@@ -34,7 +34,7 @@ defmodule Glossia.VersionControl do
   @type commit_status_state :: :pending | :success
   @spec create_commit_status(%{
           vcs_id: String.t(),
-          vcs_platform: Glossia.VersionControl.Platform.t(),
+          vcs_platform: Glossia.ContentSources.Platform.t(),
           state: commit_status_state(),
           target_url: String.t() | nil,
           description: String.t() | nil,
@@ -44,7 +44,7 @@ defmodule Glossia.VersionControl do
   def create_commit_status(%{vcs_platform: vcs_platform} = attrs) do
     case vcs_platform do
       "github" ->
-        attrs |> Glossia.VersionControl.GitHub.create_commit_status()
+        attrs |> Glossia.ContentSources.GitHub.create_commit_status()
     end
   end
 end

--- a/lib/glossia_web/controllers/api/project/localization_request_controller.ex
+++ b/lib/glossia_web/controllers/api/project/localization_request_controller.ex
@@ -20,7 +20,7 @@ defmodule GlossiaWeb.API.Project.LocalizationRequestController do
 
   def create(conn = %{body_params: %LocalizationRequest{} = localization_request}, _params) do
     GlossiaWeb.Auth.Policies.enforce!(conn, {:create, :localization_request})
-    dbg(localization_request);
+    dbg(localization_request)
     conn |> send_resp(201, "")
   end
 end

--- a/lib/glossia_web/plugs/require_payload_signature_match_plug.ex
+++ b/lib/glossia_web/plugs/require_payload_signature_match_plug.ex
@@ -15,7 +15,7 @@ defmodule GlossiaWeb.Plugs.RequirePayloadSignatureMatchPlug do
 
   @spec call(Conn.t(), term()) :: Conn.t()
   def call(%Conn{method: method} = conn, _opts) when method == "POST" or method == "PUT" do
-    case Glossia.VersionControl.is_webhook_payload_valid?(
+    case Glossia.ContentSources.is_webhook_payload_valid?(
            conn.req_headers,
            conn.assigns.raw_body,
            :github


### PR DESCRIPTION
As I gave the system more thought, I identified an interface to abstract away the sources of content (GitHub, GitLab, Contentful...). The idea of making Glossia the backend of those services is very powerful and we should build towards that. That requires designing the interface with the content source to be as generic as possible (e.g. by not using terminology that's specific to a particular content source), and leveraging Elixir primitives like Behaviours to model it.

This PR is the first step towards moving in that direction. I renamed `Glossia.VersionControl`, which assumed the content sources would be repositories, to `Glossia.ContentSources`. I introduced a "behaviour", `Glossia.ContentSources.ContentSource` with a function definition, but the behaviour is not implemented by anyone yet.