### PR TITLE
Add plan-related compile and runtime-time utilities 

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -97,6 +97,18 @@ config :ueberauth, Ueberauth,
 
 config :glossia, :env, Mix.env()
 
+supported_plans = [:community, :cloud, :enterprise]
+plan = System.get_env("GLOSSIA_PLAN", "cloud") |> String.to_atom()
+
+if Enum.member?(supported_plans, plan) do
+  config :glossia, :plan, System.get_env("GLOSSIA_PLAN", "cloud") |> String.to_atom()
+else
+  raise """
+  Invalid plan: #{inspect(plan)}.
+  Supported plans: #{inspect(supported_plans)}.
+  """
+end
+
 config :tesla, :adapter, {Tesla.Adapter.Finch, name: Glossia.Finch}
 config :oauth2, adapter: {Tesla.Adapter.Finch, name: Glossia.Finch}
 

--- a/lib/glossia/plan.ex
+++ b/lib/glossia/plan.ex
@@ -1,0 +1,27 @@
+defmodule Glossia.Plan do
+  @type plan_t :: :community | :cloud | :enterprise
+
+  @doc """
+  A macro to selectively compile code based on the plan of this instance of Glossia.
+
+  ## Parameters
+
+  - `plan` - The plan or list of plans to compile the code for.
+  - `do` - The block of code to compile.
+  """
+  defmacro only_for(plans, do: block) when is_list(plans) do
+    quote do
+      if Enum.member?(unquote(plans), Application.compile_env(:glossia, :plan, :community)) do
+        unquote(block)
+      end
+    end
+  end
+
+  @doc """
+  It returns the plan of this instance of Glossia.
+  """
+  @spec current() :: plan_t
+  def current() do
+    Application.get_env(:glossia, :plan, :community)
+  end
+end

--- a/lib/glossia/version.ex
+++ b/lib/glossia/version.ex
@@ -1,8 +1,14 @@
 defmodule Glossia.Version do
   use Boundary
 
+  # Module
+
   @current File.read!("priv/version.txt")
   @external_resource "priv/version.txt"
 
+  @doc """
+  It returns the current version of Glossia.
+  """
+  @spec current_version() :: String.t()
   def current_version, do: @current
 end


### PR DESCRIPTION
I'm adding a set of utilities to:
- Selectively compile based on the plan.
- Obtain the plan at runtime.