### PR TITLE
Rename `vcs` to `content_source`

### DIFF
--- a/lib/glossia/events.ex
+++ b/lib/glossia/events.ex
@@ -18,8 +18,8 @@ defmodule Glossia.Events do
           default_branch: String.t(),
           ref: String.t(),
           commit_sha: String.t(),
-          vcs_id: String.t(),
-          vcs_platform: atom(),
+          content_source_id: String.t(),
+          content_source_platform: atom(),
           project_handle: String.t(),
           account_handle: String.t()
         }) ::

--- a/lib/glossia/events/git_event.ex
+++ b/lib/glossia/events/git_event.ex
@@ -6,8 +6,8 @@ defmodule Glossia.Events.GitEvent do
   # Types
   @type t :: %__MODULE__{
           commit_sha: String.t(),
-          vcs_id: String.t() | nil,
-          vcs_platform: Glossia.Foundation.ContentSources.Platform.t(),
+          content_source_id: String.t() | nil,
+          content_source_platform: Glossia.Foundation.ContentSources.Platform.t(),
           vm_id: String.t() | nil,
           status: status(),
           project: Glossia.Projects.Project.t() | nil
@@ -34,8 +34,8 @@ defmodule Glossia.Events.GitEvent do
 
   schema "git_events" do
     field :commit_sha, :string
-    field :vcs_id, :string
-    field :vcs_platform, Ecto.Enum, values: [{:github, 1}]
+    field :content_source_id, :string
+    field :content_source_platform, Ecto.Enum, values: [{:github, 1}]
     field :vm_id, :string
     field :vm_logs_url, :string
     field :markdown_error_message, :string
@@ -67,8 +67,8 @@ defmodule Glossia.Events.GitEvent do
     event
     |> cast(attrs, [
       :commit_sha,
-      :vcs_id,
-      :vcs_platform,
+      :content_source_id,
+      :content_source_platform,
       :project_id,
       :status,
       :vm_id,
@@ -78,13 +78,13 @@ defmodule Glossia.Events.GitEvent do
     ])
     |> validate_required([
       :commit_sha,
-      :vcs_id,
-      :vcs_platform,
+      :content_source_id,
+      :content_source_platform,
       :project_id,
       :status,
       :event
     ])
-    |> validate_inclusion(:vcs_platform, [:github])
+    |> validate_inclusion(:content_source_platform, [:github])
     |> validate_inclusion(:event, [:push])
     |> validate_inclusion(:status, [
       :status_unknown,
@@ -98,7 +98,9 @@ defmodule Glossia.Events.GitEvent do
       :cancelled,
       :expired
     ])
-    |> unique_constraint([:commit_sha, :event, :vcs_id, :vcs_platform])
+    |> unique_constraint([:commit_sha, :event, :content_source_id, :content_source_platform],
+      name: "git_events_commit_sha_event_content_source_id_content_source_pl"
+    )
     |> assoc_constraint(:project)
   end
 end

--- a/lib/glossia/events/git_event_worker.ex
+++ b/lib/glossia/events/git_event_worker.ex
@@ -22,8 +22,8 @@ defmodule Glossia.Events.GitEventWorker do
           "default_branch" => default_branch,
           "ref" => ref,
           "commit_sha" => commit_sha,
-          "vcs_id" => vcs_id,
-          "vcs_platform" => vcs_platform,
+          "content_source_id" => content_source_id,
+          "content_source_platform" => content_source_platform,
           "project_handle" => project_handle,
           "account_handle" => account_handle
         }
@@ -39,8 +39,8 @@ defmodule Glossia.Events.GitEventWorker do
           default_branch: default_branch,
           ref: ref,
           commit_sha: commit_sha,
-          vcs_id: vcs_id,
-          vcs_platform: vcs_platform,
+          content_source_id: content_source_id,
+          content_source_platform: content_source_platform,
           project_id: project_id,
           project_handle: project_handle,
           account_handle: account_handle
@@ -54,8 +54,8 @@ defmodule Glossia.Events.GitEventWorker do
   def trigger_build(
         %{
           event: event,
-          vcs_id: vcs_id,
-          vcs_platform: vcs_platform,
+          content_source_id: content_source_id,
+          content_source_platform: content_source_platform,
           ref: ref,
           commit_sha: commit_sha,
           default_branch: default_branch,
@@ -69,7 +69,8 @@ defmodule Glossia.Events.GitEventWorker do
     git_event =
       Repo.insert!(GitEvent.changeset(%GitEvent{}, attrs))
 
-    content_source = ContentSources.new(String.to_atom(vcs_platform), vcs_id)
+    content_source =
+      ContentSources.new(String.to_atom(content_source_platform), content_source_id)
 
     ContentSources.update_state(
       content_source,
@@ -87,9 +88,9 @@ defmodule Glossia.Events.GitEventWorker do
         GLOSSIA_OWNER_HANDLE: account_handle,
         GLOSSIA_PROJECT_HANDLE: project_handle,
 
-        # VCS
-        GLOSSIA_VCS_ID: vcs_id,
-        GLOSSIA_VCS_PLATFORM: vcs_platform,
+        # Content Source
+        GLOSSIA_CONTENT_SOURCE_ID: content_source_id,
+        GLOSSIA_CONTENT_SOURCE_PLATFORM: content_source_platform,
 
         # Git
         GLOSSIA_GIT_REF: ref,

--- a/lib/glossia/foundation/content_sources/core/github.ex
+++ b/lib/glossia/foundation/content_sources/core/github.ex
@@ -248,12 +248,12 @@ defmodule Glossia.Foundation.ContentSources.Core.GitHub do
     %{access_token: access_token} |> Tentacat.Client.new()
   end
 
-  defp get_client_for_repository(vcs_id) do
+  defp get_client_for_repository(content_source_id) do
     app_jwt_token = Glossia.Foundation.ContentSources.Core.GitHub.AppToken.generate_and_sign!()
 
     {200, %{"id" => installation_id}, _} =
       Tentacat.get(
-        "repos/#{vcs_id}/installation",
+        "repos/#{content_source_id}/installation",
         Tentacat.Client.new(%{jwt: app_jwt_token})
       )
 

--- a/lib/glossia/foundation/localizations/core/workers/process_localization_request_worker.ex
+++ b/lib/glossia/foundation/localizations/core/workers/process_localization_request_worker.ex
@@ -28,7 +28,7 @@ defmodule Glossia.Foundation.Localizations.Core.Workers.ProcessLocalizationReque
         )
 
     _ =
-      ContentSources.new(project.vcs_platform, project.vcs_id)
+      ContentSources.new(project.content_source_platform, project.content_source_id)
       |> ContentSources.update_content(%{
         # TODO: Improve
         title: "Localization",

--- a/lib/glossia/projects.ex
+++ b/lib/glossia/projects.ex
@@ -41,7 +41,8 @@ defmodule Glossia.Projects do
     default_branch = opts |> Map.fetch!(:default_branch)
     project = project |> Repo.preload(:account)
 
-    content_source = ContentSources.new(project.vcs_platform, project.vcs_id)
+    content_source =
+      ContentSources.new(project.content_source_platform, project.content_source_id)
 
     {:ok, access_token} = ContentSources.generate_auth_token(content_source)
 
@@ -51,8 +52,8 @@ defmodule Glossia.Projects do
         commit_sha: commit_sha,
         default_branch: default_branch,
         ref: ref,
-        vcs_id: project.vcs_id,
-        vcs_platform: project.vcs_platform,
+        content_source_id: project.content_source_id,
+        content_source_platform: project.content_source_platform,
         project_id: project.id,
         project_handle: project.handle,
         account_handle: project.account.handle
@@ -87,8 +88,8 @@ defmodule Glossia.Projects do
   It finds a repository given the id and the vcs.
   """
   @spec find_project_by_repository(%{
-          vcs_id: String.t(),
-          vcs_platform: Project.vcs()
+          content_source_id: String.t(),
+          content_source_platform: Project.vcs()
         }) ::
           Project.t() | nil
   def find_project_by_repository(attrs) do

--- a/lib/glossia/projects/project.ex
+++ b/lib/glossia/projects/project.ex
@@ -12,8 +12,8 @@ defmodule Glossia.Projects.Project do
           account: Account.t() | nil,
           type: type(),
           visibility: visibility(),
-          vcs_id: String.t(),
-          vcs_platform: Glossia.Foundation.ContentSources.t()
+          content_source_id: String.t(),
+          content_source_platform: Glossia.Foundation.ContentSources.t()
         }
   @type visibility :: :public | :private
   @type type :: :git
@@ -31,8 +31,8 @@ defmodule Glossia.Projects.Project do
   schema "projects" do
     field :handle, :string
     field :type, Ecto.Enum, values: [{:git, 1}], default: :git
-    field :vcs_id, :string
-    field :vcs_platform, Ecto.Enum, values: [{:github, 1}]
+    field :content_source_id, :string
+    field :content_source_platform, Ecto.Enum, values: [{:github, 1}]
     field :visibility, Ecto.Enum, values: [{:private, 1}, {:public, 2}]
     belongs_to :account, Account, on_replace: :raise
     has_many(:git_events, GitEvent)
@@ -47,29 +47,47 @@ defmodule Glossia.Projects.Project do
   """
   @type changeset_attrs :: %{
           handle: String.t(),
-          vcs_id: String.t(),
-          vcs_platform: Glossia.Foundation.ContentSources.t(),
+          content_source_id: String.t(),
+          content_source_platform: Glossia.Foundation.ContentSources.t(),
           account_id: integer()
         }
   @spec changeset(project :: t(), attrs :: changeset_attrs()) :: Ecto.Changeset.t()
   def changeset(project, attrs) do
     project
-    |> cast(attrs, [:handle, :vcs_id, :vcs_platform, :account_id, :visibility, :type])
-    |> validate_required([:handle, :vcs_id, :vcs_platform, :account_id, :type])
-    |> validate_inclusion(:vcs_platform, [:github])
+    |> cast(attrs, [
+      :handle,
+      :content_source_id,
+      :content_source_platform,
+      :account_id,
+      :visibility,
+      :type
+    ])
+    |> validate_required([
+      :handle,
+      :content_source_id,
+      :content_source_platform,
+      :account_id,
+      :type
+    ])
+    |> validate_inclusion(:content_source_platform, [:github])
     |> validate_inclusion(:type, [:git])
     |> validate_format(:handle, ~r/^[a-z0-9_]+$/i, message: "must be alphanumeric")
     |> validate_length(:handle, min: 3, max: 20)
     |> unique_constraint(:handle)
-    |> unique_constraint([:vcs_id, :vcs_platform])
+    |> unique_constraint([:content_source_id, :content_source_platform])
     |> assoc_constraint(:account)
   end
 
   # Queries
 
-  def find_project_by_repository_query(%{vcs_platform: vcs_platform, vcs_id: vcs_id}) do
+  def find_project_by_repository_query(%{
+        content_source_platform: content_source_platform,
+        content_source_id: content_source_id
+      }) do
     from(p in __MODULE__,
-      where: p.vcs_id == ^vcs_id and p.vcs_platform == ^vcs_platform
+      where:
+        p.content_source_id == ^content_source_id and
+          p.content_source_platform == ^content_source_platform
     )
   end
 

--- a/lib/glossia/web/controllers/webhook_controller.ex
+++ b/lib/glossia/web/controllers/webhook_controller.ex
@@ -18,15 +18,18 @@ defmodule Glossia.Web.WebhookController do
     payload = conn.assigns.raw_body |> Jason.decode!()
     ref = payload |> get_in(["ref"])
     commit_sha = payload |> get_in(["after"])
-    vcs_id = payload |> get_in(["repository", "full_name"])
+    content_source_id = payload |> get_in(["repository", "full_name"])
     default_branch = payload |> get_in(["repository", "default_branch"])
-    content_source = ContentSources.new(:github, vcs_id)
+    content_source = ContentSources.new(:github, content_source_id)
 
     with {:should_localize, true} <-
            {:should_localize, ContentSources.should_localize?(content_source, commit_sha)},
          {:project, %Project{} = project} <-
            {:project,
-            Projects.find_project_by_repository(%{vcs_id: vcs_id, vcs_platform: :github})} do
+            Projects.find_project_by_repository(%{
+              content_source_id: content_source_id,
+              content_source_platform: :github
+            })} do
       Projects.process_git_event(project, %{
         event: event,
         ref: ref,

--- a/priv/repo/migrations/20230829093317_rename_vcs_to_content_source.exs
+++ b/priv/repo/migrations/20230829093317_rename_vcs_to_content_source.exs
@@ -1,0 +1,19 @@
+defmodule Glossia.Repo.Migrations.RenameVcsToContentSource do
+  use Ecto.Migration
+
+  def change do
+    drop unique_index(:git_events, [:commit_sha, :event, :vcs_id, :vcs_platform])
+
+    rename table(:projects), :vcs_id, to: :content_source_id
+    rename table(:projects), :vcs_platform, to: :content_source_platform
+    rename table(:git_events), :vcs_id, to: :content_source_id
+    rename table(:git_events), :vcs_platform, to: :content_source_platform
+
+    create unique_index(:git_events, [
+             :commit_sha,
+             :event,
+             :content_source_id,
+             :content_source_platform
+           ])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -16,14 +16,14 @@ organization =
   end
 
 project =
-  Repo.get_by(Project, vcs_id: "glossia/glossia", vcs_platform: :github)
+  Repo.get_by(Project, content_source_id: "glossia/glossia", content_source_platform: :github)
   |> case do
     nil ->
       {:ok, project} =
         Projects.create_project(%{
           handle: "glossia",
-          vcs_id: "glossia/glossia",
-          vcs_platform: :github,
+          content_source_id: "glossia/glossia",
+          content_source_platform: :github,
           account_id: organization.id
         })
 

--- a/priv/static/builder/utils/environment.ts
+++ b/priv/static/builder/utils/environment.ts
@@ -73,8 +73,8 @@ export function getAccessToken(env: Deno.Env = Deno.env) {
  * @param env {Deno.Env} An object containing the enviornment variables of the system.
  * @returns
  */
-export function getVCSId(env: Deno.Env = Deno.env) {
-  return env.get("GLOSSIA_VCS_ID");
+export function getContentSourceId(env: Deno.Env = Deno.env) {
+  return env.get("GLOSSIA_CONTENT_SOURCE_ID");
 }
 
 type VCSPlatform = "github";
@@ -84,10 +84,10 @@ type VCSPlatform = "github";
  * @param env {Deno.Env} An object containing the enviornment variables of the system.
  * @returns
  */
-export function getVCSPlatform(
+export function getContentSourcePlatform(
   env: Deno.Env = Deno.env,
 ): VCSPlatform | undefined {
-  const platform = env.get("GLOSSIA_VCS_PLATFORM");
+  const platform = env.get("GLOSSIA_CONTENT_SOURCE_PLATFORM");
   if (!platform) return undefined;
   switch (platform) {
     case "github":

--- a/priv/static/builder/utils/environment_test.ts
+++ b/priv/static/builder/utils/environment_test.ts
@@ -8,8 +8,8 @@ Deno.test("getEvent throws an error when the event is unsupported", () => {
   }, "This instance of the builder doesn't support the event 'invalid'");
 });
 
-Deno.test("getVCSPlatform throws an error when the VCS platform is unsupported", () => {
+Deno.test("getContentSourcePlatform throws an error when the VCS platform is unsupported", () => {
   assertThrows(() => {
-    getEvent(getMockedEnv({ GLOSSIA_VCS_PLATFORM: "invalid" }));
+    getEvent(getMockedEnv({ GLOSSIA_CONTENT_SOURCE_PLATFORM: "invalid" }));
   }, "This instance of the builder doesn't support the VCS platform 'invalid'");
 });

--- a/priv/static/builder/utils/git.ts
+++ b/priv/static/builder/utils/git.ts
@@ -1,8 +1,8 @@
 import {
+  getContentSourceId,
+  getContentSourcePlatform,
   getGitAccessToken,
   getGitCommitSHA,
-  getVCSId,
-  getVCSPlatform,
 } from "./environment.ts";
 
 // https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
@@ -13,8 +13,8 @@ export async function cloneGitRepository(
     root: root,
     gitCommitSHA: getGitCommitSHA()!,
     gitAccessToken: getGitAccessToken()!,
-    vcsPlatform: getVCSPlatform()!,
-    vcsId: getVCSId()!,
+    vcsPlatform: getContentSourcePlatform()!,
+    vcsId: getContentSourceId()!,
   });
 }
 

--- a/priv/static/builder/utils/output.ts
+++ b/priv/static/builder/utils/output.ts
@@ -2,6 +2,8 @@ import AsciiTable from "https://deno.land/x/ascii_table/mod.ts";
 import {
   getAccessToken,
   getAppSignalAPIKey,
+  getContentSourceId,
+  getContentSourcePlatform,
   getEvent,
   getGitAccessToken,
   getGitCommitSHA,
@@ -11,8 +13,6 @@ import {
   getOwnerHandle,
   getProjectHandle,
   getURL,
-  getVCSId,
-  getVCSPlatform,
 } from "../utils/environment.ts";
 
 /**
@@ -29,8 +29,8 @@ export function outputHeadingTableWithContext() {
     .addRow("Git event ID", getGitEventID())
     .addRow("Event", getEvent())
     .addRow("App Signal API key", getAppSignalAPIKey())
-    .addRow("VCS Platform", getVCSPlatform())
-    .addRow("VCS ID", getVCSId())
+    .addRow("Content Source Platform", getContentSourcePlatform())
+    .addRow("Content Source ID", getContentSourceId())
     .addRow("Git access token", getGitAccessToken())
     .addRow("Git commit SHA", getGitCommitSHA())
     .addRow("Git ref", getGitRef())

--- a/test/glossia/accounts/account_test.exs
+++ b/test/glossia/accounts/account_test.exs
@@ -18,7 +18,7 @@ defmodule Glossia.Accounts.AccountTest do
 
     test "validates the uniqueness of handle" do
       # Given
-      attrs = %{handle: "glossia"}
+      attrs = %{handle: Glossia.AccountsFixtures.unique_handle()}
       %Account{} |> Account.changeset(attrs) |> Repo.insert!()
 
       # When

--- a/test/glossia/accounts_test.exs
+++ b/test/glossia/accounts_test.exs
@@ -7,7 +7,7 @@ defmodule Glossia.AccountsTest do
   describe "register_organization" do
     test "it registers the organization successfully" do
       # Given
-      attrs = %{handle: "glossia"}
+      attrs = %{handle: Glossia.AccountsFixtures.unique_handle()}
 
       # When
       assert {:ok, _} = Accounts.register_organization(attrs)
@@ -15,7 +15,7 @@ defmodule Glossia.AccountsTest do
 
     test "errors when an organization with the same handle already exists" do
       # Given
-      attrs = %{handle: "glossia"}
+      attrs = %{handle: Glossia.AccountsFixtures.unique_handle()}
 
       # When
       assert {:ok, _} = Accounts.register_organization(attrs)

--- a/test/glossia/events/git_event_test.exs
+++ b/test/glossia/events/git_event_test.exs
@@ -25,27 +25,27 @@ defmodule Glossia.Events.GitEventTests do
 
       # Then
       errors = errors_on(changeset)
-      assert %{vcs_id: ["can't be blank"]} = errors
+      assert %{content_source_id: ["can't be blank"]} = errors
     end
 
     test "validates the presence of vcs" do
       # Given
-      attrs = %{commit_sha: "1234567890", vcs_id: "1234567890"}
+      attrs = %{commit_sha: "1234567890", content_source_id: "1234567890"}
 
       # When
       changeset = GitEvent.changeset(%GitEvent{}, attrs)
 
       # Then
       errors = errors_on(changeset)
-      assert %{vcs_platform: ["can't be blank"]} = errors
+      assert %{content_source_platform: ["can't be blank"]} = errors
     end
 
     test "validates the presence of project_id" do
       # Given
       attrs = %{
         commit_sha: "1234567890",
-        vcs_id: "1234567890",
-        vcs_platform: :github
+        content_source_id: "1234567890",
+        content_source_platform: :github
       }
 
       # When
@@ -60,8 +60,8 @@ defmodule Glossia.Events.GitEventTests do
       # Given
       attrs = %{
         commit_sha: "1234567890",
-        vcs_id: "1234567890",
-        vcs_platform: :gitlab,
+        content_source_id: "1234567890",
+        content_source_platform: :gitlab,
         project_id: 1,
         event: :push
       }
@@ -71,7 +71,7 @@ defmodule Glossia.Events.GitEventTests do
 
       # Then
       errors = errors_on(changeset)
-      assert %{vcs_platform: ["is invalid"]} = errors
+      assert %{content_source_platform: ["is invalid"]} = errors
     end
 
     test "validate the uniqueness of commit_sha, repository_id and vcs" do
@@ -80,8 +80,8 @@ defmodule Glossia.Events.GitEventTests do
 
       attrs = %{
         commit_sha: "1234567890",
-        vcs_id: "1234567890",
-        vcs_platform: :github,
+        content_source_id: "1234567890",
+        content_source_platform: :github,
         project_id: project.id,
         event: :push
       }

--- a/test/glossia/projects/project_test.exs
+++ b/test/glossia/projects/project_test.exs
@@ -7,7 +7,12 @@ defmodule Glossia.Projects.ProjectTest do
     test "validates that handle is required" do
       # Given
       project = %Project{}
-      attrs = %{vcs_id: "glossia/glossia", vcs_platform: :github, account_id: 1}
+
+      attrs = %{
+        content_source_id: "glossia/glossia",
+        content_source_platform: :github,
+        account_id: 1
+      }
 
       # When
       changeset = Project.changeset(project, attrs)
@@ -20,33 +25,38 @@ defmodule Glossia.Projects.ProjectTest do
     test "validates that repository_id is required" do
       # Given
       project = %Project{}
-      attrs = %{handle: "glossia", vcs_platform: :github, account_id: 1}
+      attrs = %{handle: "glossia", content_source_platform: :github, account_id: 1}
 
       # When
       changeset = Project.changeset(project, attrs)
 
       # Then
       errors = errors_on(changeset)
-      assert %{vcs_id: ["can't be blank"]} = errors
+      assert %{content_source_id: ["can't be blank"]} = errors
     end
 
     test "validates that vcs is required" do
       # Given
       project = %Project{}
-      attrs = %{handle: "glossia", vcs_id: "glossia/glossia", account_id: 1}
+      attrs = %{handle: "glossia", content_source_id: "glossia/glossia", account_id: 1}
 
       # When
       changeset = Project.changeset(project, attrs)
 
       # Then
       errors = errors_on(changeset)
-      assert %{vcs_platform: ["can't be blank"]} = errors
+      assert %{content_source_platform: ["can't be blank"]} = errors
     end
 
     test "validates that account_id is required" do
       # Given
       project = %Project{}
-      attrs = %{handle: "glossia", vcs_id: "glossia/glossia", vcs_platform: :github}
+
+      attrs = %{
+        handle: "glossia",
+        content_source_id: "glossia/glossia",
+        content_source_platform: :github
+      }
 
       # When
       changeset = Project.changeset(project, attrs)
@@ -62,8 +72,8 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "glossia",
-        vcs_id: "glossia/glossia",
-        vcs_platform: :invalid_vcs,
+        content_source_id: "glossia/glossia",
+        content_source_platform: :invalid_vcs,
         account_id: 1
       }
 
@@ -72,7 +82,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       # Then
       errors = errors_on(changeset)
-      assert %{vcs_platform: ["is invalid"]} = errors
+      assert %{content_source_platform: ["is invalid"]} = errors
     end
 
     test "validates that handle is alphanumeric" do
@@ -81,8 +91,8 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "invalid handle",
-        vcs_id: "glossia/glossia",
-        vcs_platform: :github,
+        content_source_id: "glossia/glossia",
+        content_source_platform: :github,
         account_id: 1
       }
 
@@ -100,8 +110,8 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "a",
-        vcs_id: "glossia/glossia",
-        vcs_platform: :github,
+        content_source_id: "glossia/glossia",
+        content_source_platform: :github,
         account_id: 1
       }
 
@@ -119,8 +129,8 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "aasdgasgasgdasdgasdgasgasdgasgsags",
-        vcs_id: "glossia/glossia",
-        vcs_platform: :github,
+        content_source_id: "glossia/glossia",
+        content_source_platform: :github,
         account_id: 1
       }
 
@@ -132,12 +142,12 @@ defmodule Glossia.Projects.ProjectTest do
       assert %{handle: ["should be at most 20 character(s)"]} = errors
     end
 
-    test "validates the inclusion of vcs_platform in the supported types" do
+    test "validates the inclusion of content_source_platform in the supported types" do
       # Given
       project = %Project{}
 
       attrs = %{
-        vcs_platform: :invalid
+        content_source_platform: :invalid
       }
 
       # When
@@ -145,7 +155,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       # Then
       errors = errors_on(changeset)
-      assert %{vcs_platform: ["is invalid"]} = errors
+      assert %{content_source_platform: ["is invalid"]} = errors
     end
 
     test "validates the inclusion of type in the supported types" do

--- a/test/glossia/projects_test.exs
+++ b/test/glossia/projects_test.exs
@@ -12,14 +12,14 @@ defmodule Glossia.ProjectsTest do
       # When
       got =
         Projects.find_project_by_repository(%{
-          vcs_id: project.vcs_id,
-          vcs_platform: project.vcs_platform
+          content_source_id: project.content_source_id,
+          content_source_platform: project.content_source_platform
         })
 
       # Then
       assert got.id == project.id
       assert got.handle == project.handle
-      assert got.vcs_id == project.vcs_id
+      assert got.content_source_id == project.content_source_id
     end
   end
 

--- a/test/support/fixtures/events_fixture.ex
+++ b/test/support/fixtures/events_fixture.ex
@@ -23,8 +23,8 @@ defmodule Glossia.EventsFixture do
   defp default_build_args() do
     %{
       commit_sha: "123",
-      vcs_id: "glossia/glossia",
-      vcs_platform: :github,
+      content_source_id: "glossia/glossia",
+      content_source_platform: :github,
       event: :push
     }
   end

--- a/test/support/fixtures/projects_fixtures.ex
+++ b/test/support/fixtures/projects_fixtures.ex
@@ -25,8 +25,9 @@ defmodule Glossia.ProjectsFixtures do
   defp project_fixture_default_attrs() do
     %{
       handle: "handle#{Glossia.TestHelpers.unique_integer()}",
-      vcs_id: "#{Glossia.TestHelpers.unique_integer()}/#{Glossia.TestHelpers.unique_integer()}",
-      vcs_platform: :github,
+      content_source_id:
+        "#{Glossia.TestHelpers.unique_integer()}/#{Glossia.TestHelpers.unique_integer()}",
+      content_source_platform: :github,
       account_id: 1
     }
   end


### PR DESCRIPTION
The name `vcs` chosen for some attributes implied that the only supported content sources were version control systems. This PR renames `vcs` to `content_source` to make them more generic.