### PR TITLE
Extract the plug that validates GitHub's webhooks signature into the `ContentSources.Web` module.

### DIFF
--- a/lib/glossia/events/event.ex
+++ b/lib/glossia/events/event.ex
@@ -11,7 +11,7 @@ defmodule Glossia.Events.Event do
           vm_id: String.t() | nil,
           status: status(),
           project: Glossia.Projects.Project.t() | nil,
-          metadata: map(),
+          metadata: map()
         }
 
   @type event :: :new_version

--- a/lib/glossia/events/event_worker.ex
+++ b/lib/glossia/events/event_worker.ex
@@ -26,7 +26,7 @@ defmodule Glossia.Events.EventWorker do
           "account_handle" => account_handle
         }
       }) do
-        git_event = Repo.get_by(Event, version: version, project_id: project_id)
+    git_event = Repo.get_by(Event, version: version, project_id: project_id)
 
     case git_event do
       nil ->
@@ -39,7 +39,7 @@ defmodule Glossia.Events.EventWorker do
           account_handle: account_handle,
           content_source_id: content_source_id,
           content_source_platform: content_source_platform,
-          content_source_access_token: content_source_access_token,
+          content_source_access_token: content_source_access_token
         })
 
       %Event{} ->
@@ -59,8 +59,6 @@ defmodule Glossia.Events.EventWorker do
           account_handle: account_handle
         } = attrs
       ) do
-
-
     event =
       Repo.insert!(Event.changeset(%Event{}, attrs))
 

--- a/lib/glossia/foundation/content_sources/core/github.ex
+++ b/lib/glossia/foundation/content_sources/core/github.ex
@@ -289,7 +289,7 @@ defmodule Glossia.Foundation.ContentSources.Core.GitHub do
     {:ok, :crypto.mac(:hmac, :sha, app_secret, payload) |> Base.encode16(case: :lower)}
   end
 
-  defp webhook_secret do
+  def webhook_secret do
     Application.get_env(:glossia, :github_app_webhooks_secret)
   end
 end

--- a/lib/glossia/foundation/content_sources/web.ex
+++ b/lib/glossia/foundation/content_sources/web.ex
@@ -1,0 +1,3 @@
+defmodule Glossia.Foundation.ContentSources.Web do
+  use Boundary, deps: [Glossia.Foundation.ContentSources.Core], exports: [Plug]
+end

--- a/lib/glossia/foundation/content_sources/web/plug.ex
+++ b/lib/glossia/foundation/content_sources/web/plug.ex
@@ -1,0 +1,12 @@
+defmodule Glossia.Foundation.ContentSources.Web.Plug do
+  # Modules
+  alias Glossia.Foundation.ContentSources.Web.Plug.GitHub
+
+  @spec init(Keyword.t()) :: Keyword.t()
+  def init(options), do: options
+
+  @spec call(Conn.t(), term()) :: Conn.t()
+  def call(conn, opts) do
+    conn |> GitHub.call(GitHub.init(opts))
+  end
+end

--- a/lib/glossia/foundation/content_sources/web/plug/github.ex
+++ b/lib/glossia/foundation/content_sources/web/plug/github.ex
@@ -1,4 +1,4 @@
-defmodule Glossia.Web.Plugs.RequirePayloadSignatureMatchPlug do
+defmodule Glossia.Foundation.ContentSources.Web.Plug.GitHub do
   @moduledoc """
   This plug will verify that the payload from a webhook request matches the accompanying header signature, based on a previously shared `webhook_secret`.
 
@@ -15,7 +15,8 @@ defmodule Glossia.Web.Plugs.RequirePayloadSignatureMatchPlug do
   def init(options), do: options
 
   @spec call(Conn.t(), term()) :: Conn.t()
-  def call(%Conn{method: method} = conn, _opts) when method == "POST" or method == "PUT" do
+  def call(%Conn{method: method, request_path: "/webhooks/github"} = conn, _opts)
+      when method == "POST" or method == "PUT" do
     content_source = ContentSources.new(:github)
 
     case ContentSources.is_webhook_payload_valid?(
@@ -34,5 +35,7 @@ defmodule Glossia.Web.Plugs.RequirePayloadSignatureMatchPlug do
     end
   end
 
-  def call(conn, _opts), do: Conn.assign(conn, :cached_body, %{})
+  def call(conn, _opts) do
+    Conn.assign(conn, :cached_body, %{})
+  end
 end

--- a/lib/glossia/projects.ex
+++ b/lib/glossia/projects.ex
@@ -17,7 +17,7 @@ defmodule Glossia.Projects do
     project
     |> process_event(%{
       type: "new_content",
-      commit_sha: "TODO",
+      commit_sha: "TODO"
     })
   end
 
@@ -26,7 +26,7 @@ defmodule Glossia.Projects do
   """
   @type process_event_opts_t :: %{
           type: String.t(),
-          version: String.t(),
+          version: String.t()
         }
   @spec process_event(project :: Project.t(), opts :: process_event_opts_t) :: :ok
 

--- a/lib/glossia/router.ex
+++ b/lib/glossia/router.ex
@@ -1,6 +1,8 @@
 defmodule Glossia.Router do
   # Modules
-  use Boundary, deps: [Glossia.Web, Glossia.Foundation.API.Web]
+  use Boundary,
+    deps: [Glossia.Web, Glossia.Foundation.API.Web, Glossia.Foundation.ContentSources.Web]
+
   use Glossia.Web, :router
   import Glossia.Web.UserAuth
 
@@ -106,7 +108,7 @@ defmodule Glossia.Router do
     plug Glossia.Web.Plugs.RawBodyPassthroughPlug, length: 4_000_000
     # It is important that this comes after `WebhookSignatureWeb.Plugs.RawBodyPassthrough`
     # as it relies on the `:raw_body` being inside the `conn.assigns`.
-    plug Glossia.Web.Plugs.RequirePayloadSignatureMatchPlug
+    plug Glossia.Foundation.ContentSources.Web.Plug
   end
 
   scope "/webhooks", Glossia.Web do

--- a/priv/repo/migrations/20230901124423_rename_git_events_to_events.exs
+++ b/priv/repo/migrations/20230901124423_rename_git_events_to_events.exs
@@ -2,12 +2,16 @@ defmodule Glossia.Repo.Migrations.RenameGitEventsToEvents do
   use Ecto.Migration
 
   def change do
-    drop unique_index(:git_events, [
-      :commit_sha,
-      :event,
-      :content_source_id,
-      :content_source_platform
-    ], name: "git_events_commit_sha_event_content_source_id_content_source_pl")
+    drop unique_index(
+           :git_events,
+           [
+             :commit_sha,
+             :event,
+             :content_source_id,
+             :content_source_platform
+           ],
+           name: "git_events_commit_sha_event_content_source_id_content_source_pl"
+         )
 
     rename table(:git_events), :commit_sha, to: :version
     rename table(:git_events), :event, to: :type
@@ -18,10 +22,10 @@ defmodule Glossia.Repo.Migrations.RenameGitEventsToEvents do
     end
 
     create unique_index(:events, [
-      :version,
-      :type,
-      :content_source_id,
-      :content_source_platform
-    ])
+             :version,
+             :type,
+             :content_source_id,
+             :content_source_platform
+           ])
   end
 end

--- a/test/glossia/events/event_test.exs
+++ b/test/glossia/events/event_test.exs
@@ -83,7 +83,7 @@ defmodule Glossia.Events.EventTest do
         version: "1234567890",
         content_source_id: "1234567890",
         content_source_platform: :github,
-        project_id: project.id,
+        project_id: project.id
       }
 
       %Event{} |> Event.changeset(attrs) |> Repo.insert!()

--- a/test/glossia/foundation/content_sources/web/github_test.exs
+++ b/test/glossia/foundation/content_sources/web/github_test.exs
@@ -1,0 +1,45 @@
+defmodule Glossia.Foundation.ContentSources.Web.Plug.GitHubTest do
+  # Modules
+  use Glossia.Web.ConnCase
+  alias Glossia.Foundation.ContentSources.Web.Plug.GitHub
+  import Plug.Conn
+
+  # Cases
+
+  test "halts the connection if the payload is invalid", %{conn: conn} do
+    # Given
+    opts = GitHub.init([])
+
+    conn = %{conn | method: "POST", request_path: "/webhooks/github"} |> assign(:raw_body, "")
+
+    # When
+    conn = conn |> GitHub.call(opts)
+
+    # Then
+    assert conn.halted == true
+
+    assert %{
+             "error" => "PAYLOAD SIGNATURE FAILED"
+           } =
+             json_response(conn, 403)
+  end
+
+  test "doesn't halt the connection if the payload is valid", %{conn: conn} do
+    # Given
+    opts = GitHub.init([])
+    payload = "payload"
+    secret = Glossia.Foundation.ContentSources.Core.GitHub.webhook_secret()
+    signature = :crypto.mac(:hmac, :sha, secret, payload) |> Base.encode16(case: :lower)
+
+    conn =
+      %{conn | method: "POST", request_path: "/webhooks/github"} |> assign(:raw_body, payload)
+
+    conn = conn |> put_req_header("x-hub-signature", "sha1=#{signature}")
+
+    # When
+    conn = conn |> GitHub.call(opts)
+
+    # Then
+    assert conn.halted == false
+  end
+end


### PR DESCRIPTION
Since the logic that validates the signature of GitHub Webhooks belongs to the content source, I'm extracting it into the `Glossia.Foundation.ContentSources.Web` from where I'm exporting a plug that groups all the content sources' plugs. I've taken the opportunity to add some tests.