### PR TITLE
Disable Posthog and AppSignal in non-cloud plans

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -79,8 +79,6 @@ config :phoenix, :plug_init_mode, :runtime
 # Disable swoosh api client as it is only required for production adapters.
 config :swoosh, :api_client, false
 
-config :appsignal, :config, active: false
-
 # OpenAPI
 
 config :open_api_spex, :cache_adapter, OpenApiSpex.Plug.NoneCache

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -16,5 +16,3 @@ config :logger, level: :info
 
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.
-
-config :appsignal, :config, active: true

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -125,11 +125,14 @@ if config_env() == :prod do
 
 
   # App Signal
-  config :appsignal, :config,
-    otp_app: :glossia,
-    name: "glossia",
-    push_api_key: env!("APP_SIGNAL_PUSH_API_KEY", :string),
-    env: :prod
+  appsignal_api_key =  env!("APP_SIGNAL_PUSH_API_KEY", :string, "")
+  if appsignal_api_key != "" do
+    config :appsignal, :config,
+      otp_app: :glossia,
+      name: "glossia",
+      push_api_key:,
+      env: :prod
+  end
 
   # Glossia Production Variables
   config :glossia,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -116,9 +116,13 @@ if config_env() == :prod do
   #
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
 
-  config :posthog,
-    api_url: env!("POSTHOG_API_URL", :string),
-    api_key: env!("POSTHOG_API_KEY", :string)
+  posthog_api_url = env!("POSTHOG_API_URL", :string, "")
+  posthog_api_key = env!("POSTHOG_API_KEY", :string, "")
+
+  if posthog_api_url != "" && posthog_api_key != "" do
+    config :posthog, api_url: posthog_api_url, api_key: posthog_api_key
+  end
+
 
   # App Signal
   config :appsignal, :config,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -123,23 +123,29 @@ if config_env() == :prod do
     config :posthog, api_url: posthog_api_url, api_key: posthog_api_key
   end
 
-
   # App Signal
-  appsignal_api_key =  env!("APP_SIGNAL_PUSH_API_KEY", :string, "")
+  appsignal_api_key = env!("APP_SIGNAL_PUSH_API_KEY", :string, "")
+
   if appsignal_api_key != "" do
     config :appsignal, :config,
       otp_app: :glossia,
       name: "glossia",
-      push_api_key:,
-      env: :prod
+      push_api_key: appsignal_api_key,
+      env: :prod,
+      active: true
+  end
+
+  appsignal_builder_api_key = env!("APP_SIGNAL_BUILDER_API_KEY", :string, "")
+
+  if appsignal_builder_api_key != "" do
+    config :glossia, app_signal_builder_api_key: env!("APP_SIGNAL_BUILDER_API_KEY", :string, "")
   end
 
   # Glossia Production Variables
   config :glossia,
     google_application_credentials_json_base_64:
       env!("GOOGLE_APPLICATION_CREDENTIALS_JSON_BASE_64", :string, ""),
-    google_cloud_project_id: env!("GOOGLE_CLOUD_PROJECT_ID", :string, ""),
-    app_signal_builder_api_key: env!("APP_SIGNAL_BUILDER_API_KEY", :string, "")
+    google_cloud_project_id: env!("GOOGLE_CLOUD_PROJECT_ID", :string, "")
 end
 
 # Glossia

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -153,7 +153,6 @@ config :glossia,
   github_app_webhooks_secret: env!("GITHUB_APP_WEBHOOKS_SECRET", :string, ""),
   github_app_id: env!("GITHUB_APP_ID", :string, ""),
   github_app_bot_user: env!("GITHUB_APP_BOT_USER", :string, ""),
-  builder_api_key: env!("BUILDER_API_KEY", :string, ""),
   url: if(config_env() == :prod, do: "https://glossia.ai", else: "http://127.0.0.1:4000"),
   openai_chatgpt_secret_key: env!("OPENAI_CHATGPT_SECRET_KEY", :string, "")
 

--- a/lib/glossia/foundation/virtual_machine/core.ex
+++ b/lib/glossia/foundation/virtual_machine/core.ex
@@ -226,8 +226,7 @@ defmodule Glossia.Foundation.VirtualMachine.Core do
   defp get_docker_env_variables() do
     variables = %{
       GLOSSIA_ENV: "production",
-      GLOSSIA_URL: Application.get_env(:glossia, :url),
-      GLOSSIA_API_KEY: Application.get_env(:glossia, :builder_api_key)
+      GLOSSIA_URL: Application.get_env(:glossia, :url)
     }
 
     app_signal_builder_api_key = Application.get_env(:glossia, :app_signal_builder_api_key)
@@ -254,7 +253,7 @@ defmodule Glossia.Foundation.VirtualMachine.Core do
     deno_allow_env_flags =
       (Enum.reduce(env, [], fn {k, _}, acc ->
          [Atom.to_string(k) | acc]
-       end) ++ ["GLOSSIA_URL", "GLOSSIA_APP_SIGNAL_API_KEY", "GLOSSIA_API_KEY", "GITHUB_TOKEN"])
+       end) ++ ["GLOSSIA_URL", "GLOSSIA_APP_SIGNAL_API_KEY", "GITHUB_TOKEN"])
       |> Enum.join(",")
 
     [

--- a/lib/glossia/foundation/virtual_machine/core.ex
+++ b/lib/glossia/foundation/virtual_machine/core.ex
@@ -224,12 +224,22 @@ defmodule Glossia.Foundation.VirtualMachine.Core do
 
   @spec get_docker_env_variables() :: map()
   defp get_docker_env_variables() do
-    %{
+    variables = %{
       GLOSSIA_ENV: "production",
       GLOSSIA_URL: Application.get_env(:glossia, :url),
-      GLOSSIA_API_KEY: Application.get_env(:glossia, :builder_api_key),
-      GLOSSIA_APP_SIGNAL_API_KEY: Application.get_env(:glossia, :app_signal_builder_api_key)
+      GLOSSIA_API_KEY: Application.get_env(:glossia, :builder_api_key)
     }
+
+    app_signal_builder_api_key = Application.get_env(:glossia, :app_signal_builder_api_key)
+
+    if app_signal_builder_api_key do
+      variables
+      |> Map.merge(%{
+        GLOSSIA_APP_SIGNAL_API_KEY: Application.get_env(:glossia, :app_signal_builder_api_key)
+      })
+    else
+      variables
+    end
   end
 
   @spec get_deno_args(attrs :: [env: map()]) :: [String.t()]

--- a/mix.exs
+++ b/mix.exs
@@ -65,8 +65,6 @@ defmodule Glossia.MixProject do
       {:makeup_erlang, "~> 0.1.0"},
       {:timex, "~> 3.0"},
       {:joken, "~> 2.6.0"},
-      {:appsignal, "~> 2.0"},
-      {:appsignal_phoenix, "~> 2.0"},
       {:plug_attack, "~> 0.4.2"},
       {:remote_ip, "1.1.0"},
       {:ex_json_schema, "~> 0.10.0"},
@@ -93,7 +91,9 @@ defmodule Glossia.MixProject do
       :cloud ->
         dependencies ++ [
           {:posthog, "~> 0.1"},
-          {:oban_web, "~> 2.10.0-rc.2", repo: "oban", optional: true}
+          {:oban_web, "~> 2.10.0-rc.2", repo: "oban", optional: true},
+          {:appsignal, "~> 2.0"},
+          {:appsignal_phoenix, "~> 2.0"}
         ]
       _ -> dependencies
     end

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,6 @@ defmodule Glossia.MixProject do
       {:ueberauth, "~> 0.10.5"},
       {:ueberauth_github, "~> 0.8"},
       {:tentacat, "~> 2.2"},
-      {:posthog, "~> 0.1"},
       {:nimble_publisher, "~> 1.0.0"},
       {:makeup_elixir, "~> 0.16.0"},
       {:makeup_erlang, "~> 0.1.0"},
@@ -92,7 +91,10 @@ defmodule Glossia.MixProject do
     ]
     case plan() do
       :cloud ->
-        dependencies ++ [{:oban_web, "~> 2.10.0-rc.2", repo: "oban", optional: true}]
+        dependencies ++ [
+          {:posthog, "~> 0.1"},
+          {:oban_web, "~> 2.10.0-rc.2", repo: "oban", optional: true}
+        ]
       _ -> dependencies
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -87,15 +87,19 @@ defmodule Glossia.MixProject do
       {:primer_live, "~> 0.5"},
       {:ecto_erd, "~> 0.5", only: :dev}
     ]
+
     case plan() do
       :cloud ->
-        dependencies ++ [
-          {:posthog, "~> 0.1"},
-          {:oban_web, "~> 2.10.0-rc.2", repo: "oban", optional: true},
-          {:appsignal, "~> 2.0"},
-          {:appsignal_phoenix, "~> 2.0"}
-        ]
-      _ -> dependencies
+        dependencies ++
+          [
+            {:posthog, "~> 0.1"},
+            {:oban_web, "~> 2.10.0-rc.2", repo: "oban", optional: true},
+            {:appsignal, "~> 2.0"},
+            {:appsignal_phoenix, "~> 2.0"}
+          ]
+
+      _ ->
+        dependencies
     end
   end
 


### PR DESCRIPTION
I'm disabling analytics via Posthog and error tracking via AppSignal in non-cloud plans.