### PR TITLE
Enable dialyzer

### DIFF
--- a/.github/workflows/glossia.yml
+++ b/.github/workflows/glossia.yml
@@ -109,7 +109,9 @@ jobs:
       - name: Add Oban Web repository
         run: mix hex.repo add oban https://getoban.pro/repo --fetch-public-key $OBAN_WEB_FETCH_PUBLIC_KEY --auth-key $OBAN_WEB_AUTH_KEY;
 
-      - run: mix deps.get
+      - env:
+          MIX_ENV: dev
+        run: mix deps.get
 
       - env:
           MIX_ENV: dev

--- a/.github/workflows/glossia.yml
+++ b/.github/workflows/glossia.yml
@@ -83,35 +83,35 @@ jobs:
       - run: mix deps.get
 
       - run: mix credo
-  # There are some issues to be addressed before it can be enabled
-  # dialyzer:
-  #   name: Dialyzer
-  #   runs-on: 'ubuntu-latest'
-  #   timeout-minutes: 15
-  #   steps:
-  #     - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
 
-  #     - uses: erlef/setup-elixir@v1
-  #       with:
-  #         otp-version: ${{ env.OTP_VERSION }}
-  #         elixir-version: ${{ env.ELIXIR_VERSION }}
+  dialyzer:
+    name: Dialyzer
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
 
-  #     - name: Restore Cache
-  #       uses: actions/cache@v3
-  #       id: mix-cache
-  #       with:
-  #         path: |
-  #           deps
-  #           _build
-  #           _site
-  #         key: mix-${{ hashFiles('mix.lock') }}
+      - uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
 
-  #     - name: Add Oban Web repository
-  #       run: mix hex.repo add oban https://getoban.pro/repo --fetch-public-key $OBAN_WEB_FETCH_PUBLIC_KEY --auth-key $OBAN_WEB_AUTH_KEY;
+      - name: Restore Cache
+        uses: actions/cache@v3
+        id: mix-cache
+        with:
+          path: |
+            deps
+            _build
+            _site
+          key: mix-${{ hashFiles('mix.lock') }}
 
-  #     - run: mix deps.get
+      - name: Add Oban Web repository
+        run: mix hex.repo add oban https://getoban.pro/repo --fetch-public-key $OBAN_WEB_FETCH_PUBLIC_KEY --auth-key $OBAN_WEB_AUTH_KEY;
 
-  #     - run: mix dialyzer
+      - run: mix deps.get
+
+      - run: mix dialyzer
   community_dry_run:
     name: Community Image Dry Run
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/glossia.yml
+++ b/.github/workflows/glossia.yml
@@ -111,7 +111,9 @@ jobs:
 
       - run: mix deps.get
 
-      - run: mix dialyzer
+      - env:
+          MIX_ENV: dev
+        run: mix dialyzer
   community_dry_run:
     name: Community Image Dry Run
     runs-on: 'ubuntu-latest'

--- a/lib/glossia/foundation/accounts/core/models/account.ex
+++ b/lib/glossia/foundation/accounts/core/models/account.ex
@@ -3,17 +3,17 @@ defmodule Glossia.Foundation.Accounts.Core.Models.Account do
   A module that represents the accounts table
   """
 
-  # Types
-  @type t :: %__MODULE__{
-          handle: String.t(),
-          projects: [Project.t()] | nil
-        }
-
   # Modules
   import Ecto.Query, only: [from: 2]
   use Ecto.Schema
   import Ecto.Changeset
   alias Glossia.Foundation.Projects.Core.Models.Project
+
+  # Types
+  @type t :: %__MODULE__{
+          handle: String.t(),
+          projects: [Project.t()] | nil
+        }
 
   # Schema
 
@@ -62,7 +62,8 @@ defmodule Glossia.Foundation.Accounts.Core.Models.Account do
   @doc """
 
   """
-  @spec changeset(account :: t(), attrs :: create_account_changeset_attrs()) :: Ecto.Changeset.t()
+  @spec changeset(account :: Ecto.Schema.t(), attrs :: create_account_changeset_attrs()) ::
+          Ecto.Changeset.t()
   def changeset(account, attrs) do
     account
     |> cast(attrs, [:handle])

--- a/lib/glossia/foundation/accounts/core/models/credentials.ex
+++ b/lib/glossia/foundation/accounts/core/models/credentials.ex
@@ -1,5 +1,6 @@
 defmodule Glossia.Foundation.Accounts.Core.Models.Credentials do
-  alias Glossia.Foundation.Accounts.Core.{User}
+  # Modules
+  alias Glossia.Foundation.Accounts.Core.Models.{User}
   import Ecto.Changeset
 
   @type provider :: :github
@@ -30,7 +31,7 @@ defmodule Glossia.Foundation.Accounts.Core.Models.Credentials do
   @doc """
   It returns the default changeset for the credentials table.
   """
-  @spec changeset(credentials :: t(), attrs :: map()) ::
+  @spec changeset(credentials :: Ecto.Schema.t(), attrs :: map()) ::
           Ecto.Changeset.t()
   def changeset(credentials, attrs \\ %{}) do
     credentials

--- a/lib/glossia/foundation/accounts/core/models/organization.ex
+++ b/lib/glossia/foundation/accounts/core/models/organization.ex
@@ -26,12 +26,7 @@ defmodule Glossia.Foundation.Accounts.Core.Models.Organization do
   end
 
   # Changesets
-  @type create_organization_changeset_attrs :: %{
-          account: map()
-        }
-
-  @spec create_organization_changeset(attrs :: create_organization_changeset_attrs) ::
-          Ecto.Changeset.t()
+  @spec create_organization_changeset(attrs :: map()) :: Ecto.Changeset.t()
   def create_organization_changeset(attrs) do
     %__MODULE__{}
     |> cast(attrs, [:account_id])

--- a/lib/glossia/foundation/accounts/core/models/organization_user.ex
+++ b/lib/glossia/foundation/accounts/core/models/organization_user.ex
@@ -1,7 +1,7 @@
 defmodule Glossia.Foundation.Accounts.Core.Models.OrganizationUser do
   use Ecto.Schema
   import Ecto.Changeset
-  alias Glossia.Foundation.Accounts.Core.{Organization, User}
+  alias Glossia.Foundation.Accounts.Core.Models.{Organization, User}
 
   # Type
   @type t :: %__MODULE__{

--- a/lib/glossia/foundation/accounts/core/models/user.ex
+++ b/lib/glossia/foundation/accounts/core/models/user.ex
@@ -1,13 +1,4 @@
 defmodule Glossia.Foundation.Accounts.Core.Models.User do
-  @type t :: %__MODULE__{
-          email: String.t(),
-          password: String.t(),
-          hashed_password: String.t(),
-          confirmed_at: DateTime.t(),
-          credentials: [Credentials.t()],
-          account: [Account.t()]
-        }
-
   @moduledoc """
   A struct that represents the users table.
   """
@@ -16,6 +7,16 @@ defmodule Glossia.Foundation.Accounts.Core.Models.User do
 
   alias Glossia.Foundation.Projects.Core.Models.Project
   alias Glossia.Foundation.Accounts.Core.Models.{Account, Credentials, Organization}
+
+  # Types
+  @type t :: %__MODULE__{
+          email: String.t(),
+          password: String.t(),
+          hashed_password: String.t(),
+          confirmed_at: DateTime.t(),
+          credentials: [Credentials.t()],
+          account: [Account.t()]
+        }
 
   schema "users" do
     field :email, :string

--- a/lib/glossia/foundation/accounts/web/helpers/auth.ex
+++ b/lib/glossia/foundation/accounts/web/helpers/auth.ex
@@ -2,7 +2,7 @@ defmodule Glossia.Foundation.Accounts.Web.Helpers.Auth do
   @doc """
   It returns true if there's a user authenticated in the given connection.
   """
-  @spec user_authenticated?(Conn.t()) :: boolean()
+  @spec user_authenticated?(Plug.Conn.t()) :: boolean()
   def user_authenticated?(conn) do
     conn.assigns[:authenticated_user] != nil
   end
@@ -10,7 +10,8 @@ defmodule Glossia.Foundation.Accounts.Web.Helpers.Auth do
   @doc """
   If there's a user authenticated in the given connection it returns the user, otherwise it returns nil.
   """
-  @spec authenticated_user(Conn.t()) :: Glossia.Foundation.Accounts.Core.Models.User.t() | nil
+  @spec authenticated_user(Plug.Conn.t()) ::
+          Glossia.Foundation.Accounts.Core.Models.User.t() | nil
   def authenticated_user(conn) do
     conn.assigns[:authenticated_user]
   end

--- a/lib/glossia/foundation/api/web/controllers/project/localization_request_controller.ex
+++ b/lib/glossia/foundation/api/web/controllers/project/localization_request_controller.ex
@@ -8,7 +8,6 @@ defmodule Glossia.Foundation.API.Web.Controllers.Project.LocalizationRequestCont
 
   tags ["localization-requests"]
 
-  alias Glossia.Foundation.Projects.Core.Models.Project
   alias Glossia.Foundation.Localizations.Core, as: Localizations
   alias Glossia.Foundation.API.Core.Schemas.LocalizationRequest.CreateResponse
   alias Glossia.Foundation.Localizations.Core.API.Schemas.LocalizationRequest
@@ -21,14 +20,10 @@ defmodule Glossia.Foundation.API.Web.Controllers.Project.LocalizationRequestCont
       ok: {"Localization request response", "application/json", CreateResponse}
     ]
 
-  @spec create(
-          conn :: %{
-            body_params: LocalizationRequest.t(),
-            assigns: %{authenticated_project: Project.t()}
-          },
-          params :: map()
-        ) :: Plug.Conn.t()
-  def create(%{body_params: %LocalizationRequest{} = request} = conn, _params) do
+  @spec create(conn :: Plug.Conn.t(), any) :: Plug.Conn.t()
+  @dialyzer {:nowarn_function, create: 2}
+  def create(conn, _params) do
+    %{body_params: %LocalizationRequest{} = request} = conn
     Glossia.Foundation.Accounts.Web.Policies.enforce!(conn, {:create, :localization_request})
 
     result =

--- a/lib/glossia/foundation/builds/core/build.ex
+++ b/lib/glossia/foundation/builds/core/build.ex
@@ -3,7 +3,8 @@ defmodule Glossia.Foundation.Builds.Core.Build do
   @type t :: %__MODULE__{
           version: String.t(),
           content_source_id: String.t() | nil,
-          content_source_platform: Glossia.Foundation.ContentSources.Platform.t(),
+          content_source_platform:
+            Glossia.Foundation.ContentSources.Core.ContentSource.content_source_t(),
           vm_id: String.t() | nil,
           status: status(),
           project: Glossia.Foundation.Projects.Core.Models.Project.t() | nil,

--- a/lib/glossia/foundation/content_sources/core/content_source.ex
+++ b/lib/glossia/foundation/content_sources/core/content_source.ex
@@ -1,6 +1,8 @@
 defmodule Glossia.Foundation.ContentSources.Core.ContentSource do
   @type version_t :: :latest | {:version, String.t()}
 
+  @type content_source_t :: :github
+
   @doc """
   It returns the content from a content source.
 
@@ -10,7 +12,7 @@ defmodule Glossia.Foundation.ContentSources.Core.ContentSource do
   - `version` - The version of the content. It can be `:latest` or a specific version. In the case of content sources like GitHub, it represents the commit SHA when pulling a specific version.
   """
   @callback get_content(
-              content_source :: any(),
+              content_source :: content_source_t(),
               content_id :: String.t(),
               version :: version_t
             ) ::

--- a/lib/glossia/foundation/content_sources/core/github.ex
+++ b/lib/glossia/foundation/content_sources/core/github.ex
@@ -113,9 +113,11 @@ defmodule Glossia.Foundation.ContentSources.Core.GitHub do
               "repos/#{github.owner}/#{github.repo}/commits/#{commit_sha}/branches-where-head",
               github.client
             )},
-         {:commit, {status, %{"commit" => %{"tree" => %{"sha" => commit_tree_sha}}}, _}}
+         {:fetch_head_commit,
+          {status, %{"commit" => %{"tree" => %{"sha" => commit_tree_sha}}}, _}}
          when status in 200..299 <-
-           {:commit, Tentacat.Commits.find(github.client, commit_sha, github.owner, github.repo)},
+           {:fetch_head_commit,
+            Tentacat.Commits.find(github.client, commit_sha, github.owner, github.repo)},
          {:tree, tree} <-
            {:tree,
             %{
@@ -145,9 +147,12 @@ defmodule Glossia.Foundation.ContentSources.Core.GitHub do
             )} do
       {:ok, %{id: created_commit_sha, url: commit_url}}
     else
+      {:fetch_head_commit, {_, body, _}} -> {:error, body}
+      {:commit_creation, {_, body, _}} -> {:error, body}
       {:branch, {200, [] = _, _}} -> {:error, :newer_version_exists}
       {:branch, {_, body, _}} -> {:error, body}
       {:tree_creation, {_, body, _}} -> {:error, body}
+      {:reference_update, {_, body, _}} -> {:error, body}
     end
   end
 
@@ -258,7 +263,11 @@ defmodule Glossia.Foundation.ContentSources.Core.GitHub do
           Tentacat.Client.t()
   defp get_client_for_installation(installation_id, app_jwk_token) do
     app_jwt_token =
-      app_jwk_token || Glossia.Foundation.ContentSources.Core.GitHub.AppToken.generate_and_sign!()
+      if app_jwk_token != nil do
+        app_jwk_token
+      else
+        Glossia.Foundation.ContentSources.Core.GitHub.AppToken.generate_and_sign!()
+      end
 
     client = Tentacat.Client.new(%{jwt: app_jwt_token})
 

--- a/lib/glossia/foundation/content_sources/web/plug.ex
+++ b/lib/glossia/foundation/content_sources/web/plug.ex
@@ -5,7 +5,7 @@ defmodule Glossia.Foundation.ContentSources.Web.Plug do
   @spec init(Keyword.t()) :: Keyword.t()
   def init(options), do: options
 
-  @spec call(Conn.t(), term()) :: Plug.Conn.t()
+  @spec call(Plug.Conn.t(), term()) :: Plug.Conn.t()
   def call(conn, opts) do
     conn |> GitHub.call(GitHub.init(opts))
   end

--- a/lib/glossia/foundation/content_sources/web/plug.ex
+++ b/lib/glossia/foundation/content_sources/web/plug.ex
@@ -5,7 +5,7 @@ defmodule Glossia.Foundation.ContentSources.Web.Plug do
   @spec init(Keyword.t()) :: Keyword.t()
   def init(options), do: options
 
-  @spec call(Conn.t(), term()) :: Conn.t()
+  @spec call(Conn.t(), term()) :: Plug.Conn.t()
   def call(conn, opts) do
     conn |> GitHub.call(GitHub.init(opts))
   end

--- a/lib/glossia/foundation/localizations/core.ex
+++ b/lib/glossia/foundation/localizations/core.ex
@@ -10,7 +10,6 @@ defmodule Glossia.Foundation.Localizations.Core do
     exports: [API.Schemas.LocalizationRequest]
 
   alias Glossia.Foundation.ContentSources.Core, as: ContentSources
-  alias Glossia.Localizations.API.Schemas.LocalizationRequest
   alias Glossia.Foundation.Localizations.Core.Workers.LocalizeWorker
   alias Glossia.Foundation.Projects.Core, as: Projects
 
@@ -26,7 +25,7 @@ defmodule Glossia.Foundation.Localizations.Core do
   - `opts` - The options to process the localization request.
   """
   @spec process_localization_request(
-          request :: LocalizationRequest.t(),
+          request :: any(),
           opts :: process_localization_request_opts()
         ) :: :ok | {:error, term()}
   def process_localization_request(request, %{project_id: project_id} = _opts) do

--- a/lib/glossia/foundation/projects/core.ex
+++ b/lib/glossia/foundation/projects/core.ex
@@ -15,18 +15,6 @@ defmodule Glossia.Foundation.Projects.Core do
   alias Glossia.Foundation.ContentSources.Core, as: ContentSources
 
   @doc """
-  It simulates a git push event using the latest commit from the default branch of a project.
-  """
-  @spec simulate_new_content_event(Project.t()) :: :ok
-  def simulate_new_content_event(project) do
-    project
-    |> trigger_build(%{
-      type: "new_content",
-      commit_sha: "TODO"
-    })
-  end
-
-  @doc """
   Given a git event, it processes it.
   """
   @spec trigger_build(Project.t(), %{type: String.t(), version: String.t()}) :: :ok

--- a/lib/glossia/foundation/projects/web/plugs/redirect_to_default_project_when_authenticated_plug.ex
+++ b/lib/glossia/foundation/projects/web/plugs/redirect_to_default_project_when_authenticated_plug.ex
@@ -7,7 +7,7 @@ defmodule Glossia.Foundation.Projects.Web.Plugs.RedirectToDefaultProjectWhenAuth
   @spec init(Keyword.t()) :: Keyword.t()
   def init(options), do: options
 
-  @spec call(Conn.t(), term()) :: Conn.t()
+  @spec call(Plug.Conn.t(), term()) :: Plug.Conn.t()
   def call(
         %{request_path: "/"} = conn,
         _opts

--- a/mix.exs
+++ b/mix.exs
@@ -93,7 +93,7 @@ defmodule Glossia.MixProject do
         dependencies ++
           [
             {:posthog, "~> 0.1"},
-            {:oban_web, "~> 2.10.0-rc.2", repo: "oban", optional: true},
+            {:oban_web, "~> 2.10.0-rc.2", repo: "oban"},
             {:appsignal, "~> 2.0"},
             {:appsignal_phoenix, "~> 2.0"}
           ]


### PR DESCRIPTION
Dialyzer, although not perfect, increases the confidence when iterating on the code because it ensure the type contracts are met. This PR solves all the current issues and adjusts the CI pipeline to run it as part of CI.