### PR TITLE
Use OpenStatus for monitoring the status of Glossia

### DIFF
--- a/lib/glossia/features/cloud/marketing/web/components.ex
+++ b/lib/glossia/features/cloud/marketing/web/components.ex
@@ -180,7 +180,7 @@ defmodule Glossia.Features.Cloud.Marketing.Web.Components do
                     <li>
                       <a
                         class="text-lg text-black hover:text-lila-400"
-                        href="https://status.glossia.ai"
+                        href="https://glossia.openstatus.dev/"
                       >
                         Status
                       </a>


### PR DESCRIPTION
To help other COSS projects thrive, we are adopting [OpenStatus](https://www.openstatus.dev/) as our service to monitor the status of Glossia.