### PR TITLE
Configure contributor license agreement

### DIFF
--- a/.github/cla/README.md
+++ b/.github/cla/README.md
@@ -1,0 +1,67 @@
+
+### Individual Contributor License Agreement
+
+Thank you for your interest in contributing to open source software projects made available by Glossia GmbH. This Individual Contributor License Agreement (“Agreement”) sets out the terms governing any source code, object code, bug fixes, configuration changes, tools, specifications, documentation, data, materials, feedback, information or other works of authorship that you submit or have submitted, in any form and in any manner, to Glossia in respect of any of the Projects (collectively “Contributions”). If you have any questions respecting this Agreement, please contact hello@glossia.ai
+
+
+You agree that the following terms apply to all of your past, present and future Contributions. Except for the licenses granted in this Agreement, you retain all of your right, title and interest in and to your Contributions.
+
+
+**Copyright License.** You hereby grant, and agree to grant, to Glossia a non-exclusive, perpetual, irrevocable, worldwide, fully-paid, royalty-free, transferable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute your Contributions and such derivative works, with the right to sublicense the foregoing rights through multiple tiers of sublicensees.
+
+
+**Patent License.** You hereby grant, and agree to grant, to Glossia a non-exclusive, perpetual, irrevocable,
+worldwide, fully-paid, royalty-free, transferable patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer your Contributions, where such license applies only to those patent claims
+licensable by you that are necessarily infringed by your Contributions alone or by combination of your
+Contributions with the Project to which such Contributions were submitted, with the right to sublicense the
+foregoing rights through multiple tiers of sublicensees.
+
+
+**Moral Rights.** To the fullest extent permitted under applicable law, you hereby waive, and agree not to
+assert, all of your “moral rights” in or relating to your Contributions for the benefit of Glossia, its assigns, and
+their respective direct and indirect sublicensees.
+
+
+**Third Party Content/Rights.** If your Contribution includes or is based on any source code, object code, bug
+fixes, configuration changes, tools, specifications, documentation, data, materials, feedback, information or
+other works of authorship that were not authored by you (“Third Party Content”) or if you are aware of any
+third party intellectual property or proprietary rights associated with your Contribution (“Third Party Rights”),
+then you agree to include with the submission of your Contribution full details respecting such Third Party
+Content and Third Party Rights, including, without limitation, identification of which aspects of your
+Contribution contain Third Party Content or are associated with Third Party Rights, the owner/author of the
+Third Party Content and Third Party Rights, where you obtained the Third Party Content, and any applicable
+third party license terms or restrictions respecting the Third Party Content and Third Party Rights. For greater
+certainty, the foregoing obligations respecting the identification of Third Party Content and Third Party Rights
+do not apply to any portion of a Project that is incorporated into your Contribution to that same Project.
+
+
+**Representations.** You represent that, other than the Third Party Content and Third Party Rights identified by
+you in accordance with this Agreement, you are the sole author of your Contributions and are legally entitled
+to grant the foregoing licenses and waivers in respect of your Contributions. If your Contributions were
+created in the course of your employment with your past or present employer(s), you represent that such
+employer(s) has authorized you to make your Contributions on behalf of such employer(s) or such employer
+(s) has waived all of their right, title or interest in or to your Contributions.
+
+
+**Disclaimer.** To the fullest extent permitted under applicable law, your Contributions are provided on an "asis"
+basis, without any warranties or conditions, express or implied, including, without limitation, any implied
+warranties or conditions of non-infringement, merchantability or fitness for a particular purpose. You are not
+required to provide support for your Contributions, except to the extent you desire to provide support.
+
+
+**No Obligation.** You acknowledge that Glossia is under no obligation to use or incorporate your Contributions
+into any of the Projects. The decision to use or incorporate your Contributions into any of the Projects will be
+made at the sole discretion of Glossia or its authorized delegates.
+
+
+**Disputes.** This Agreement shall be governed by and construed in accordance with the laws of the State of
+New York, United States of America, without giving effect to its principles or rules regarding conflicts of laws,
+other than such principles directing application of New York law. The parties hereby submit to venue in, and
+jurisdiction of the courts located in New York, New York for purposes relating to this Agreement. In the event
+that any of the provisions of this Agreement shall be held by a court or other tribunal of competent jurisdiction
+to be unenforceable, the remaining portions hereof shall remain in full force and effect.
+
+
+**Assignment.** You agree that Glossia may assign this Agreement, and all of its rights, obligations and licenses
+hereunder.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,27 @@
+name: "CLA"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: './github/cla/signatures.json'
+          path-to-document: 'https://github.com/glossia/glossia/blob/main/.github/cla/README.md'
+          branch: 'main'
+          allowlist: 'bot*,*dependabot*'


### PR DESCRIPTION
I'm adding a **contributor license agreement** and a GitHub Actions workflow that ensures that new contributors sign it before landing their contribution to the project.