### PR TITLE
Ensure only admin users can access the Oban dashboard

### DIFF
--- a/lib/glossia/foundation/accounts/core/models/user.ex
+++ b/lib/glossia/foundation/accounts/core/models/user.ex
@@ -9,13 +9,15 @@ defmodule Glossia.Foundation.Accounts.Core.Models.User do
   alias Glossia.Foundation.Accounts.Core.Models.{Account, Credentials, Organization}
 
   # Types
+  @type role :: :user | :admin
   @type t :: %__MODULE__{
           email: String.t(),
           password: String.t(),
           hashed_password: String.t(),
           confirmed_at: DateTime.t(),
           credentials: [Credentials.t()],
-          account: [Account.t()]
+          account: Account.t() | nil,
+          role: role
         }
 
   schema "users" do
@@ -23,6 +25,7 @@ defmodule Glossia.Foundation.Accounts.Core.Models.User do
     field :password, :string, virtual: true, redact: true
     field :hashed_password, :string, redact: true
     field :confirmed_at, :naive_datetime
+    field :role, Ecto.Enum, values: [user: 1, admin: 2], default: :user
 
     has_many :credentials, Credentials, on_delete: :delete_all
     belongs_to :account, Account, on_replace: :raise

--- a/lib/glossia/foundation/accounts/core/policies.ex
+++ b/lib/glossia/foundation/accounts/core/policies.ex
@@ -10,12 +10,20 @@ defmodule Glossia.Foundation.Accounts.Core.Policies do
     :ok
   end
 
-  def policy(%{authenticated_user: nil}, :authenticated_user_present) do
+  def policy(_, :authenticated_user_present) do
     {:error, :authenticated_user_absent}
   end
 
-  def policy(%{}, :authenticated_user_present) do
-    {:error, :authenticated_user_absent}
+  def policy(%{authenticated_user: %User{} = user}, :authenticate_user_is_admin) do
+    if user.role == :admin do
+      :ok
+    else
+      {:error, :authenticated_user_is_not_admin}
+    end
+  end
+
+  def policy(_, :authenticate_user_is_admin) do
+    {:error, :authenticated_user_is_not_admin}
   end
 
   def policy_error(conn, _) do

--- a/lib/glossia/foundation/accounts/web/plugs/policies_plug.ex
+++ b/lib/glossia/foundation/accounts/web/plugs/policies_plug.ex
@@ -16,6 +16,13 @@ defmodule Glossia.Foundation.Accounts.Web.Plugs.PoliciesPlug do
     |> halt()
   end
 
+  def policy_error(conn, :authenticated_user_is_not_admin) do
+    conn
+    |> put_flash(:error, "You are not authorized to visit this page")
+    |> redirect(to: ~p"/")
+    |> halt()
+  end
+
   defp maybe_store_return_to(%{method: "GET"} = conn) do
     put_session(conn, :user_return_to, current_path(conn))
   end

--- a/lib/glossia/foundation/application/web/router.ex
+++ b/lib/glossia/foundation/application/web/router.ex
@@ -148,6 +148,25 @@ defmodule Glossia.Foundation.Application.Web.Router do
     plug Glossia.Foundation.Projects.Web.Plugs.PoliciesPlug, {:read, :project}
   end
 
+  pipeline :ensure_authenticated_user_is_admin do
+    plug Glossia.Foundation.Accounts.Web.Plugs.PoliciesPlug, :authenticate_user_is_admin
+  end
+
+  scope "/admin" do
+    pipe_through [
+      :browser,
+      :app,
+      :load_authenticated_user,
+      :authenticated_user_present,
+      :ensure_authenticated_user_is_admin
+    ]
+
+    only_for_plans([:cloud]) do
+      import Oban.Web.Router
+      oban_dashboard("/oban")
+    end
+  end
+
   scope "/auth", Glossia.Foundation.Accounts.Web.Controllers do
     pipe_through [:browser, :app]
 
@@ -179,15 +198,6 @@ defmodule Glossia.Foundation.Application.Web.Router do
     scope "/" do
       pipe_through [:browser, :app]
       live "/new", Glossia.Foundation.Projects.Web.LiveViews.NewLiveView
-    end
-  end
-
-  scope "/admin" do
-    pipe_through [:browser, :app, :load_authenticated_user, :authenticated_user_present]
-
-    only_for_plans([:cloud]) do
-      import Oban.Web.Router
-      oban_dashboard("/oban")
     end
   end
 

--- a/priv/repo/migrations/20230924145856_add_role_to_users.exs
+++ b/priv/repo/migrations/20230924145856_add_role_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Glossia.Foundation.Database.Core.Repo.Migrations.AddRoleToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :role, :integer, null: false, default: 0
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -3,7 +3,6 @@ alias Glossia.Foundation.Accounts.Core, as: Accounts
 alias Glossia.Foundation.Accounts.Core.Models.Account
 alias Glossia.Foundation.Projects.Core, as: Projects
 alias Glossia.Foundation.Projects.Core.Models.Project
-alias Glossia.Foundation.Accounts.Core.Models.Organization
 
 organization =
   Repo.get_by(Account, handle: "glossia")


### PR DESCRIPTION
The Oban dashboard is a utility for the organization managing the production instance and is only available in the cloud instance. Because of that, I'm restricting its access only to the users flagged as admin in the database. For that, I needed to add a new column, `role`, which defaults to `user.`