### PR TITLE
Ensure content source id and platform uniqueness across projects

### DIFF
--- a/lib/glossia/foundation/projects/core/models/project.ex
+++ b/lib/glossia/foundation/projects/core/models/project.ex
@@ -63,7 +63,7 @@ defmodule Glossia.Foundation.Projects.Core.Models.Project do
     |> validate_inclusion(:content_source_platform, [:github])
     |> validate_format(:handle, ~r/^[a-z0-9_]+$/i, message: "must be alphanumeric")
     |> validate_length(:handle, min: 3, max: 20)
-    |> unique_constraint(:handle)
+    |> unique_constraint([:account_id, :handle])
     |> unique_constraint([:content_source_id, :content_source_platform])
     |> assoc_constraint(:account)
   end

--- a/lib/glossia/foundation/projects/core/policies.ex
+++ b/lib/glossia/foundation/projects/core/policies.ex
@@ -35,25 +35,31 @@ defmodule Glossia.Foundation.Projects.Core.Policies do
   end
 
   def policy(
-        %{url_project: url_project} = assigns,
+        %{url_project: _} = assigns,
         {:read, :project}
       ) do
-    policy(Map.merge(%{project: url_project}, assigns), {:read, :project})
+    {project, assigns} = assigns |> Map.pop(:url_project)
+    policy(Map.merge(%{project: project}, assigns), {:read, :project})
   end
 
   def policy(
-        %{authenticated_user: authenticated_user} = assigns,
+        %{authenticated_user: _} = assigns,
         {:read, :project}
       ) do
-    policy(Map.merge(%{user: authenticated_user}, assigns), {:read, :project})
+    {user, assigns} = assigns |> Map.pop(:authenticated_user)
+
+    policy(Map.merge(%{user: user}, assigns), {:read, :project})
   end
 
   def policy(
         %{url_project: url_project, authenticated_user: authenticated_user} = assigns,
         {:read, :project}
       ) do
+    {user, assigns} = assigns |> Map.pop(:authenticated_user)
+    {project, assigns} = assigns |> Map.pop(:url_project)
+
     policy(
-      Map.merge(%{user: authenticated_user, project: url_project}, assigns),
+      Map.merge(%{user: user, project: project}, assigns),
       {:read, :project}
     )
   end

--- a/lib/glossia/foundation/projects/core/policies.ex
+++ b/lib/glossia/foundation/projects/core/policies.ex
@@ -52,7 +52,7 @@ defmodule Glossia.Foundation.Projects.Core.Policies do
   end
 
   def policy(
-        %{url_project: url_project, authenticated_user: authenticated_user} = assigns,
+        %{url_project: _, authenticated_user: _} = assigns,
         {:read, :project}
       ) do
     {user, assigns} = assigns |> Map.pop(:authenticated_user)

--- a/lib/glossia/foundation/projects/web/controllers/project_controller.ex
+++ b/lib/glossia/foundation/projects/web/controllers/project_controller.ex
@@ -2,15 +2,6 @@ defmodule Glossia.Foundation.Projects.Web.Controllers.ProjectController do
   use Glossia.Foundation.Application.Web.Helpers.App, :controller
 
   def show(conn, _params) do
-    render(conn, :new)
-  end
-
-  def new(conn, _params) do
-    conn
-    |> put_open_graph_metadata(%{
-      title: "New project",
-      description: "Create a new project"
-    })
-    |> render(:new)
+    render(conn, :show)
   end
 end

--- a/lib/glossia/foundation/projects/web/controllers/project_html.ex
+++ b/lib/glossia/foundation/projects/web/controllers/project_html.ex
@@ -1,5 +1,9 @@
 defmodule Glossia.Foundation.Projects.Web.Controllers.ProjectHTML do
   use Glossia.Foundation.Application.Web.Helpers.App, :html
 
-  embed_templates "project_html/*"
+  def show(assigns) do
+    ~H"""
+    <div><%= @url_project.handle %></div>
+    """
+  end
 end

--- a/lib/glossia/foundation/projects/web/live_views/new_live_view.ex
+++ b/lib/glossia/foundation/projects/web/live_views/new_live_view.ex
@@ -53,7 +53,27 @@ defmodule Glossia.Foundation.Projects.Web.LiveViews.NewLiveView do
         {:noreply, redirect(socket, to: ~p"/#{account.handle}/#{project.handle}")}
 
       {:error, changeset} ->
-        {:noreply, assign(socket, project_changeset: changeset)}
+        {:noreply, assign(socket, project_changeset: changeset |> map_error_changeset)}
     end
+  end
+
+  @spec map_error_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  defp map_error_changeset(changeset) do
+    errors = changeset.errors || []
+
+    changeset =
+      with {:content_source_id_errors, {_, attrs}} when errors != nil <-
+             {:content_source_id_errors, Keyword.get(errors, :content_source_id)},
+           {:error_constraint, :unique} <- {:error_constraint, Keyword.get(attrs, :constraint)} do
+        changeset
+        |> Ecto.Changeset.add_error(
+          :content_source_id,
+          "Another project is already linked to this repository."
+        )
+      else
+        _ -> changeset
+      end
+
+    changeset
   end
 end

--- a/lib/glossia/foundation/projects/web/live_views/new_live_view.html.heex
+++ b/lib/glossia/foundation/projects/web/live_views/new_live_view.html.heex
@@ -17,7 +17,6 @@
     <.text_input
       form={f}
       field={:handle}
-      id="handle"
       is_form_control
       form_control={
         %{
@@ -31,7 +30,6 @@
       <.select
         form={f}
         field={:content_source_id}
-        id="content_source_id"
         options={@repositories}
         is_form_control
         prompt={[key: "Select the repository", disabled: true, selected: true]}

--- a/lib/glossia/foundation/projects/web/live_views/new_live_view.html.heex
+++ b/lib/glossia/foundation/projects/web/live_views/new_live_view.html.heex
@@ -30,9 +30,16 @@
     <div class="appearance-none">
       <.select
         form={f}
-        name="content_source_id"
+        field={:content_source_id}
+        id="content_source_id"
         options={@repositories}
         is_form_control
+        prompt={[key: "Select the repository", disabled: true, selected: true]}
+        form_control={
+          %{
+            label: "Select the repository"
+          }
+        }
         caption={
           fn ->
             ~H'''

--- a/priv/repo/migrations/20230924154601_add_uniqueness_to_projects_content_source_id_and_platform.exs
+++ b/priv/repo/migrations/20230924154601_add_uniqueness_to_projects_content_source_id_and_platform.exs
@@ -1,0 +1,7 @@
+defmodule Glossia.Foundation.Database.Core.Repo.Migrations.AddUniquenessToProjectsContentSourceIdAndPlatform do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:projects, [:content_source_id, :content_source_platform])
+  end
+end


### PR DESCRIPTION
I added a unique constraint to the database that ensures that content source id and platforms are unique across all the projects. Since a combination of both, i.e. a repository in the case of GitHub, is a shared state, having multiple projects pointing to the same repository might lead to race conditions that are hard to reason about and debug. As part of this PR I'm also updating the new project live view to ensure the right validation message is presented to the user.