### PR TITLE
Not start the endpoint and oban if there's no flame parent

### DIFF
--- a/lib/glossia/application.ex
+++ b/lib/glossia/application.ex
@@ -6,6 +6,8 @@ defmodule Glossia.Application do
 
   @impl true
   def start(_type, _args) do
+    flame_parent = FLAME.Parent.get()
+
     Glossia.Secrets.load()
 
     Oban.Telemetry.attach_default_logger()
@@ -19,13 +21,9 @@ defmodule Glossia.Application do
 
     children =
       [
-        # Start the Telemetry supervisor
         GlossiaWeb.Telemetry,
-        # Start the Ecto repository
         Glossia.Repo,
-        # Start the PubSub system
         {Phoenix.PubSub, name: Glossia.PubSub},
-        # Start Finch
         {Finch,
          name: Glossia.Finch,
          pools: %{
@@ -34,13 +32,16 @@ defmodule Glossia.Application do
              conn_opts: [recv_timeout: :timer.minutes(5), send_timeout: :timer.minutes(5)]
            ]
          }},
-        # Start the Endpoint (http/https)
-        GlossiaWeb.Endpoint,
-        # Start a worker by calling: Glossia.Worker.start_link(arg)
-        # {Glossia.Worker, arg}
-        {Oban, Application.fetch_env!(:glossia, Oban)},
-        {Task.Supervisor, name: Glossia.TaskSupervisor},
-        {FLAME.Pool, name: Glossia.EventProcessor, min: 1, max: 10, max_concurrency: 100}
+        {FLAME.Pool,
+         name: Glossia.EventProcessor,
+         min: 0,
+         max: 10,
+         max_concurrency: 1,
+         idle_shutdown_after: 10_000,
+         log: :debug},
+        !flame_parent && GlossiaWeb.Endpoint,
+        !flame_parent && {Oban, Application.fetch_env!(:glossia, Oban)},
+        {Task.Supervisor, name: Glossia.TaskSupervisor}
       ] ++ google_cloud_children()
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/glossia_web/controllers/webhooks/github_webhooks_controller.ex
+++ b/lib/glossia_web/controllers/webhooks/github_webhooks_controller.ex
@@ -27,10 +27,9 @@ defmodule GlossiaWeb.Controllers.Webhooks.GitHubWebhooksController do
               content_source_id: content_source_id,
               content_source_platform: :github
             })} do
-
-              FLAME.call(Glossia.EventProcessor, fn ->
-                IO.puts "Hello world"
-              end)
+      FLAME.call(Glossia.EventProcessor, fn ->
+        IO.puts("Hello world")
+      end)
 
       # Projects.trigger_build(project, %{
       #   type: "new_content",


### PR DESCRIPTION
I'm adjusting the `start` function of `application.ex` not to start the HTTP server and Oban endpoint when there's a Flame parent, which means the process runs a FLAME task.
I took the opportunity to adjust the configuration a bit:
- `max_concurrency:` We only do one clone per host. We can tweak this in the future to support multiple clones. As long as there's enough disk space and the clone paths are unique in the file system, there shouldn't be any issue with increasing the concurrency.
- `idle_shutdown_after:` I set it to 10 seconds to shut hosts down if they are booted and receive no FLAME task within that timeframe.