### PR TITLE
Add macros to conditionally include code based on the flavor of the app

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,7 @@ Copyright (c) 2020-present María José Salmerón Ibáñez & Pedro Piñera Buend
 Portions of this software are licensed as follows:
 
 * All content that resides under https://github.com/glossia/glossia/tree/main/lib/ee directory of this repository (Commercial License) is licensed under the license defined in "lib/ee/LICENSE".
-* All content within that resides under https://github.com/glossia/glossia/tree/main/lib/prop, unless explicitly stated otherwise, is not available for use, copying, modification, or distribution without a specific agreement with María José Salmerón Ibáñez & Pedro Piñera Buendía. Unauthorized use is strictly prohibited.
+* All content within that resides under https://github.com/glossia/glossia/tree/main/lib/cloud, unless explicitly stated otherwise, is not available for use, copying, modification, or distribution without a specific agreement with María José Salmerón Ibáñez & Pedro Piñera Buendía. Unauthorized use is strictly prohibited.
 * All third party components incorporated into the Glossia Software are licensed under the original license provided by the owner of the applicable component.
 * Content outside of the above mentioned directories or restrictions above is available under the "AGPLv3" license as defined below.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -135,3 +135,6 @@ config :lightning_css,
     cd: Path.expand("..", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]
+
+# Flavor
+config :glossia, :flavor, System.get_env("GLOSSIA_FLAVOR", "cloud")

--- a/lib/glossia/flavor.ex
+++ b/lib/glossia/flavor.ex
@@ -1,0 +1,23 @@
+defmodule Glossia.Flavor do
+  @flavor Application.compile_env!(:glossia, :flavor) |> String.to_atom()
+
+  defmacro only_for_flavors(flavors, do: block) do
+    quote do
+      if Enum.member?(unquote(flavors), Glossia.Flavor.current()) do
+        unquote(block)
+      end
+    end
+  end
+
+  defmacro excluding_from_flavors(flavors, do: block) do
+    quote do
+      unless Enum.member?(unquote(flavors), Glossia.Flavor.current()) do
+        unquote(block)
+      end
+    end
+  end
+
+  def current() do
+    @flavor
+  end
+end

--- a/lib/glossia_web/router.ex
+++ b/lib/glossia_web/router.ex
@@ -56,19 +56,21 @@ defmodule GlossiaWeb.Router do
     plug :put_root_layout, html: {GlossiaWeb.Layouts.Docs, :root}
   end
 
-  # We read the value from the compiled docs to ensure if the slug changes the compilation of the router fails.
-  whats_glossia_docs_slug =
-    Glossia.Docs.Content.pages()
-    |> Enum.find(&(&1.slug == "users/what-is-glossia"))
-    |> Map.get(:slug)
+  only_for_flavors [:cloud] do
+    # We read the value from the compiled docs to ensure if the slug changes the compilation of the router fails.
+    whats_glossia_docs_slug =
+      Glossia.Docs.Content.pages()
+      |> Enum.find(&(&1.slug == "users/what-is-glossia"))
+      |> Map.get(:slug)
 
-  redirect("/docs", "/docs/#{whats_glossia_docs_slug}", :permanent)
+    redirect("/docs", "/docs/#{whats_glossia_docs_slug}", :permanent)
 
-  scope "/", GlossiaWeb.Controllers do
-    pipe_through [:browser, :docs, :tracking]
+    scope "/", GlossiaWeb.Controllers do
+      pipe_through [:browser, :docs, :tracking]
 
-    for page <- Glossia.Docs.Content.pages() do
-      get "/docs/#{page.slug}", DocsController, :show
+      for page <- Glossia.Docs.Content.pages() do
+        get "/docs/#{page.slug}", DocsController, :show
+      end
     end
   end
 
@@ -117,9 +119,11 @@ defmodule GlossiaWeb.Router do
     plug :accepts, ["xml"]
   end
 
-  scope "/", GlossiaWeb.Controllers do
-    pipe_through [:rss, :tracking]
-    get "/blog/feed.xml", MarketingController, :feed
+  only_for_flavors [:cloud] do
+    scope "/", GlossiaWeb.Controllers do
+      pipe_through [:rss, :tracking]
+      get "/blog/feed.xml", MarketingController, :feed
+    end
   end
 
   ##### Webhook Routes #####

--- a/lib/glossia_web/router.ex
+++ b/lib/glossia_web/router.ex
@@ -4,6 +4,7 @@ defmodule GlossiaWeb.Router do
   import Phoenix.LiveView.Router
   import Plug.Conn
   import Redirect
+  import Glossia.Flavor
   use Phoenix.Router, helpers: false
 
   ##### Base pipelines #####
@@ -35,18 +36,20 @@ defmodule GlossiaWeb.Router do
     plug :put_root_layout, html: {GlossiaWeb.Layouts.Marketing, :root}
   end
 
-  scope "/", GlossiaWeb.Controllers do
-    pipe_through [:browser, :marketing, :tracking]
+  only_for_flavors [:cloud] do
+    scope "/", GlossiaWeb.Controllers do
+      pipe_through [:browser, :marketing, :tracking]
 
-    get "/", MarketingController, :index
-    get "/beta", MarketingController, :beta
-    get "/about", MarketingController, :about
-    get "/team", MarketingController, :team
-    get "/beta-added", MarketingController, :beta_added
-    get "/blog", MarketingController, :blog
-    get "/blog/posts/:year/:month/:day/:id", MarketingController, :blog_post
-    get "/terms", MarketingController, :terms
-    get "/privacy", MarketingController, :privacy
+      get "/", MarketingController, :index
+      get "/beta", MarketingController, :beta
+      get "/about", MarketingController, :about
+      get "/team", MarketingController, :team
+      get "/beta-added", MarketingController, :beta_added
+      get "/blog", MarketingController, :blog
+      get "/blog/posts/:year/:month/:day/:id", MarketingController, :blog_post
+      get "/terms", MarketingController, :terms
+      get "/privacy", MarketingController, :privacy
+    end
   end
 
   pipeline :docs do


### PR DESCRIPTION
Three flavors of Glossia match the three licenses available:

- **Community:** a minimal self-hostable version for projects that need a primary continuous localization pipeline in their projects.
- **Enterprise:** A more feature-complete hostable version of Glossia with advanced continuous localization features. It requires an enterprise license before hosting it.
- **Cloud:** A version only hostable by Glossia with features that combine features shared across the above two flavors and features that are unique to the cloud flavor.

This PR adds a module, `Glossia.Flavor`, which provides Elixir macros for conditionally including code based on the compile-time flavor:

```exs
import Glossia.Flavor

only_for_flavors [:cloud] do
 # Cloud code here
end

excluding_from_flavors [:cloud] do
 # Community and enterprise code here
end
```