### PR TITLE
Rename .tool-versions to mise.toml and adjust the CI pipelines to use Mise

### DIFF
--- a/.github/workflows/glossia.yml
+++ b/.github/workflows/glossia.yml
@@ -30,7 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: jdx/mise-action@v2
-      - run: chmod +x /home/runner/.local/share/mise/plugins/elixir/shims/mix
       - name: Restore Cache
         uses: actions/cache@v3
         id: mix-cache
@@ -49,7 +48,6 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: jdx/mise-action@v2
-      - run: chmod +x /home/runner/.local/share/mise/plugins/elixir/shims/mix
       - name: Restore Cache
         uses: actions/cache@v3
         id: mix-cache
@@ -69,7 +67,6 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: jdx/mise-action@v2
-      - run: chmod +x /home/runner/.local/share/mise/plugins/elixir/shims/mix
       - name: Restore Cache
         uses: actions/cache@v3
         id: mix-cache

--- a/.github/workflows/glossia.yml
+++ b/.github/workflows/glossia.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: jdx/mise-action@v2
+      - run: chmod +x /home/runner/.local/share/mise/plugins/elixir/shims/mix
       - name: Restore Cache
         uses: actions/cache@v3
         id: mix-cache
@@ -48,6 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: jdx/mise-action@v2
+      - run: chmod +x /home/runner/.local/share/mise/plugins/elixir/shims/mix
       - name: Restore Cache
         uses: actions/cache@v3
         id: mix-cache
@@ -67,6 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: jdx/mise-action@v2
+      - run: chmod +x /home/runner/.local/share/mise/plugins/elixir/shims/mix
       - name: Restore Cache
         uses: actions/cache@v3
         id: mix-cache

--- a/.github/workflows/glossia.yml
+++ b/.github/workflows/glossia.yml
@@ -12,9 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEBUG: 1
-  OTP_VERSION: 26.1.1
-  ELIXIR_VERSION: 1.16.0
   MIX_ENV: test
   MASTER_KEY: ${{ secrets.MASTER_KEY }}
 
@@ -32,12 +29,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-      - uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-
+      - uses: jdx/mise-action@v2
       - name: Restore Cache
         uses: actions/cache@v3
         id: mix-cache
@@ -47,9 +39,7 @@ jobs:
             _build
             _site
           key: mix-${{ hashFiles('mix.lock') }}
-
       - run: mix deps.get
-
       - run: mix test
   credo:
     name: Credo
@@ -57,12 +47,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-      - uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-
+      - uses: jdx/mise-action@v2
       - name: Restore Cache
         uses: actions/cache@v3
         id: mix-cache
@@ -72,9 +57,7 @@ jobs:
             _build
             _site
           key: mix-${{ hashFiles('mix.lock') }}
-
       - run: mix deps.get
-
       - run: mix credo
 
   dialyzer:
@@ -83,12 +66,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-      - uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-
+      - uses: jdx/mise-action@v2
       - name: Restore Cache
         uses: actions/cache@v3
         id: mix-cache
@@ -98,11 +76,9 @@ jobs:
             _build
             _site
           key: mix-${{ hashFiles('mix.lock') }}
-
       - env:
           MIX_ENV: dev
         run: mix deps.get
-
       - env:
           MIX_ENV: dev
         run: mix dialyzer

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,9 @@
+[env]
+MIX_ENV = 'dev'
+GLOSSIA_FLAVOR = 'cloud'
+
+[tools]
+"elixir" = "1.16.0"
+"flyctl" = "0.1.104"
+"deno" = "1.39.1"
+"erlang" = "26.2.1"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,4 @@
 [env]
-MIX_ENV = 'dev'
 GLOSSIA_FLAVOR = 'cloud'
 
 [plugins]

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,9 @@
 MIX_ENV = 'dev'
 GLOSSIA_FLAVOR = 'cloud'
 
+[plugins]
+elixir = "https://github.com/mise-plugins/mise-elixir"
+
 [tools]
 "elixir" = "1.16.0"
 "flyctl" = "0.1.104"

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-README.md
-test-project
-definition-manifest.json
-.vscode
-.npmignore

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,0 @@
-elixir 1.16.0
-flyctl 0.1.104
-deno   1.39.1
-node 20.5.0
-erlang 26.2.1


### PR DESCRIPTION
Glossia uses [Mise](https://github.com/jdx/mise) to set up the environment locally. This PR changes the configuration to use the `.mise.toml` configuration file instead of `.tool-versions`, a very simple spec proposed by the precursor of Mise, [asdf](https://asdf-vm.com/). `.mise.toml` supports features beyond specifying the versions of the tools to use, like setting environment variables that are automatically set when choosing a directory.

This PR also adjusts the GitHub Actions workflows to use Mise to provision the environment with the right tools.