### PR TITLE
Build all the flavors of Glossia in every commit

### DIFF
--- a/.github/workflows/glossia.yml
+++ b/.github/workflows/glossia.yml
@@ -82,8 +82,8 @@ jobs:
       - env:
           MIX_ENV: dev
         run: mix dialyzer
-  dry_run:
-    name: Image Dry Run
+  cloud_dry_run:
+    name: Dry Run (Cloud)
     runs-on: 'ubuntu-latest'
     timeout-minutes: 15
     steps:
@@ -92,4 +92,26 @@ jobs:
         uses: ScribeMD/docker-cache@0.3.7
         with:
           key: docker-cloud-${{ runner.os }}-${{ hashFiles('Dockerfile') }}
-      - run: docker build . -t glossia
+      - run: docker build . -t glossia_cloud --build-arg MIX_ENV=prod --build-arg GLOSSIA_FLAVOR=cloud
+  community_dry_run:
+    name: Dry Run (Community)
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.3.7
+        with:
+          key: docker-cloud-${{ runner.os }}-${{ hashFiles('Dockerfile') }}
+      - run: docker build . -t glossia_community --build-arg MIX_ENV=prod --build-arg GLOSSIA_FLAVOR=community
+  enterprise_dry_run:
+    name: Dry Run (Enterprise)
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.3.7
+        with:
+          key: docker-cloud-${{ runner.os }}-${{ hashFiles('Dockerfile') }}
+      - run: docker build . -t glossia_enterprise --build-arg MIX_ENV=prod --build-arg GLOSSIA_FLAVOR=enterprise

--- a/lib/glossia_web/layouts/app/app.html.heex
+++ b/lib/glossia_web/layouts/app/app.html.heex
@@ -1,4 +1,4 @@
-<.link
+<%!-- <.link
   href={~p"/auth/logout"}
   method="delete"
   class="flex items-center px-4 py-2.5 text-sm font-medium transition-all duration-200 text-gray-900 rounded-lg hover:bg-gray-200 group"
@@ -19,7 +19,7 @@
     />
   </svg>
   Logout
-</.link>
+</.link> --%>
 
 <main>
   <%= @inner_content %>

--- a/lib/glossia_web/layouts/app/project.html.heex
+++ b/lib/glossia_web/layouts/app/project.html.heex
@@ -1,0 +1,4 @@
+<main>
+  <div>Hello world</div>
+  <%= @inner_content %>
+</main>

--- a/lib/glossia_web/router.ex
+++ b/lib/glossia_web/router.ex
@@ -7,8 +7,6 @@ defmodule GlossiaWeb.Router do
   import Glossia.Flavor
   use Phoenix.Router, helpers: false
 
-  ##### Base pipelines #####
-
   pipeline :browser do
     plug :accepts, ["html"]
 
@@ -24,6 +22,12 @@ defmodule GlossiaWeb.Router do
     plug GlossiaWeb.Auth, :load_authenticated_subject
   end
 
+  only_for_flavors [:cloud] do
+    pipeline :docs do
+      plug :put_root_layout, html: {GlossiaWeb.Layouts.Docs, :root}
+    end
+  end
+
   pipeline :tracking do
     plug GlossiaWeb.LiveViewMountablePlug, :track_page
   end
@@ -32,8 +36,55 @@ defmodule GlossiaWeb.Router do
     plug GlossiaWeb.LiveViewMountablePlug, :load_url_project
   end
 
-  pipeline :marketing do
-    plug :put_root_layout, html: {GlossiaWeb.Layouts.Marketing, :root}
+  only_for_flavors [:cloud] do
+    pipeline :marketing do
+      plug :put_root_layout, html: {GlossiaWeb.Layouts.Marketing, :root}
+    end
+  end
+
+  pipeline :api do
+    plug :accepts, ["json"]
+
+    plug Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      json_decoder: Phoenix.json_library()
+
+    plug OpenApiSpex.Plug.PutApiSpec, module: GlossiaWeb.APISpec
+    plug GlossiaWeb.Auth, :load_authenticated_subject
+  end
+
+  only_for_flavors [:cloud] do
+    pipeline :rss do
+      plug :accepts, ["xml"]
+    end
+  end
+
+  pipeline :webhooks do
+    plug :accepts, ["json"]
+    plug GlossiaWeb.Plugs.RawBodyPassthroughPlug, length: 4_000_000
+    # It is important that this comes after `WebhookSignatureWeb.Plugs.RawBodyPassthrough`
+    # as it relies on the `:raw_body` being inside the `conn.assigns`.
+    plug GlossiaWeb.Plugs.ValidateGitHubWebhookPlug
+  end
+
+  pipeline :app do
+    plug :put_root_layout, html: {GlossiaWeb.Layouts.App, :root}
+  end
+
+  pipeline :ensure_authenticated_subject_present do
+    plug GlossiaWeb.Auth, :ensure_authenticated_subject_present
+  end
+
+  pipeline :ensure_authenticated_subject_can_read_admin do
+    plug Glossia.Authorization.Plug,
+      policy: Glossia.Admin,
+      action: :read,
+      subject: {GlossiaWeb.Auth, :authenticated_subject}
+  end
+
+  pipeline :project do
+    plug GlossiaWeb.LiveViewMountablePlug, :project
   end
 
   only_for_flavors [:cloud] do
@@ -50,10 +101,6 @@ defmodule GlossiaWeb.Router do
       get "/terms", MarketingController, :terms
       get "/privacy", MarketingController, :privacy
     end
-  end
-
-  pipeline :docs do
-    plug :put_root_layout, html: {GlossiaWeb.Layouts.Docs, :root}
   end
 
   only_for_flavors [:cloud] do
@@ -74,22 +121,6 @@ defmodule GlossiaWeb.Router do
     end
   end
 
-  ##### API Routes #####
-
-  pipeline :api do
-    plug :accepts, ["json"]
-
-    plug Plug.Parsers,
-      parsers: [:urlencoded, :multipart, :json],
-      pass: ["*/*"],
-      json_decoder: Phoenix.json_library()
-
-    plug OpenApiSpex.Plug.PutApiSpec, module: GlossiaWeb.APISpec
-    plug GlossiaWeb.Auth, :load_authenticated_subject
-  end
-
-  # Authenticated builder API endpoints:
-  # These endpoints authenticate and authorize the authenticated entities
   scope "/api/v1" do
     pipe_through [
       :api,
@@ -104,19 +135,11 @@ defmodule GlossiaWeb.Router do
     end
   end
 
-  # Unauthenticated builder API endpoints:
-  # There are some endpoints, like the one that returns the OpenAPI spec, that don't
-  # require being authenticated because they don't return resource-tied data.
-  scope "/api/v1" do
+  scope "/api/v1" do # Unauthenticated endpoints
     pipe_through [:api, :tracking]
 
     get "/openapi", OpenApiSpex.Plug.RenderSpec, []
     match(:*, "/*path", GlossiaWeb.Controllers.API.APIController, :not_found)
-  end
-
-  ##### RSS Routes #####
-  pipeline :rss do
-    plug :accepts, ["xml"]
   end
 
   only_for_flavors [:cloud] do
@@ -124,15 +147,6 @@ defmodule GlossiaWeb.Router do
       pipe_through [:rss, :tracking]
       get "/blog/feed.xml", MarketingController, :feed
     end
-  end
-
-  ##### Webhook Routes #####
-  pipeline :webhooks do
-    plug :accepts, ["json"]
-    plug GlossiaWeb.Plugs.RawBodyPassthroughPlug, length: 4_000_000
-    # It is important that this comes after `WebhookSignatureWeb.Plugs.RawBodyPassthrough`
-    # as it relies on the `:raw_body` being inside the `conn.assigns`.
-    plug GlossiaWeb.Plugs.ValidateGitHubWebhookPlug
   end
 
   scope "/webhooks" do
@@ -143,27 +157,6 @@ defmodule GlossiaWeb.Router do
          :github
 
     post "/stripe", GlossiaWeb.Controllers.Webhooks.StripeWebhooksController, :create
-  end
-
-  ##### App Routes #####
-
-  pipeline :app do
-    plug :put_root_layout, html: {GlossiaWeb.Layouts.App, :root}
-  end
-
-  pipeline :ensure_authenticated_subject_present do
-    plug GlossiaWeb.Auth, :ensure_authenticated_subject_present
-  end
-
-  pipeline :ensure_authenticated_subject_can_read_admin do
-    plug Glossia.Authorization.Plug,
-      policy: Glossia.Admin,
-      action: :read,
-      subject: {GlossiaWeb.Auth, :authenticated_subject}
-  end
-
-  pipeline :project do
-    plug GlossiaWeb.LiveViewMountablePlug, :project
   end
 
   scope "/admin" do

--- a/lib/glossia_web/router.ex
+++ b/lib/glossia_web/router.ex
@@ -135,7 +135,8 @@ defmodule GlossiaWeb.Router do
     end
   end
 
-  scope "/api/v1" do # Unauthenticated endpoints
+  # Unauthenticated endpoints
+  scope "/api/v1" do
     pipe_through [:api, :tracking]
 
     get "/openapi", OpenApiSpex.Plug.RenderSpec, []
@@ -188,7 +189,8 @@ defmodule GlossiaWeb.Router do
     ]
 
     live_session :project_live_session,
-      on_mount: {GlossiaWeb.LiveViewMountablePlug, :project_live_session} do
+      on_mount: {GlossiaWeb.LiveViewMountablePlug, :project_live_session},
+      layout: {GlossiaWeb.Layouts.App, :project} do
       live "/:owner_handle/:project_handle", GlossiaWeb.LiveViews.Projects.Dashboard
       live "/:owner_handle/:project_handle/versions", GlossiaWeb.LiveViews.Projects.Versions
       live "/:owner_handle/:project_handle/events", GlossiaWeb.LiveViews.Projects.Events


### PR DESCRIPTION
This PR extends the CI pipeline to build the Docker image of all the flavors to ensure no compile-time regressions are introduced. This is important since, in development, we'll be working most of the time with the cloud flavor of the app. Note that this CI step won't be able to catch issues in the business logic. Those will need to be caught through tests.