### PR TITLE
Rename "content source" to "content source platform"

### DIFF
--- a/.github/workflows/glossia.yml
+++ b/.github/workflows/glossia.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
     services:
       db:
-        image: postgres:16
+        image: postgres:14.11
         ports: ['5432:5432']
         env:
           POSTGRES_PASSWORD: postgres

--- a/lib/glossia/builds/build.ex
+++ b/lib/glossia/builds/build.ex
@@ -29,7 +29,7 @@ defmodule Glossia.Builds.Build do
 
   schema "builds" do
     field :version, :string
-    field :content_source_platform, Ecto.Enum, values: [{:github, 1}]
+    field :content_platform, Ecto.Enum, values: [{:github, 1}]
     field :vm_id, :string
     field :vm_logs_url, :string
     field :markdown_error_message, :string
@@ -62,7 +62,7 @@ defmodule Glossia.Builds.Build do
     event
     |> cast(attrs, [
       :version,
-      :content_source_platform,
+      :content_platform,
       :project_id,
       :status,
       :vm_id,
@@ -72,12 +72,12 @@ defmodule Glossia.Builds.Build do
     ])
     |> validate_required([
       :version,
-      :content_source_platform,
+      :content_platform,
       :project_id,
       :status,
       :type
     ])
-    |> validate_inclusion(:content_source_platform, [:github])
+    |> validate_inclusion(:content_platform, [:github])
     |> validate_inclusion(:type, [:new_version])
     |> validate_inclusion(:status, [
       :status_unknown,

--- a/lib/glossia/builds/build.ex
+++ b/lib/glossia/builds/build.ex
@@ -4,8 +4,6 @@ defmodule Glossia.Builds.Build do
   # Types
   @type t :: %__MODULE__{
           version: String.t(),
-          content_source_id: String.t() | nil,
-          content_source_platform: atom(),
           vm_id: String.t() | nil,
           status: status(),
           project: Glossia.Projects.Project.t() | nil,
@@ -31,7 +29,6 @@ defmodule Glossia.Builds.Build do
 
   schema "builds" do
     field :version, :string
-    field :content_source_id, :string
     field :content_source_platform, Ecto.Enum, values: [{:github, 1}]
     field :vm_id, :string
     field :vm_logs_url, :string
@@ -65,7 +62,6 @@ defmodule Glossia.Builds.Build do
     event
     |> cast(attrs, [
       :version,
-      :content_source_id,
       :content_source_platform,
       :project_id,
       :status,
@@ -76,7 +72,6 @@ defmodule Glossia.Builds.Build do
     ])
     |> validate_required([
       :version,
-      :content_source_id,
       :content_source_platform,
       :project_id,
       :status,
@@ -96,8 +91,8 @@ defmodule Glossia.Builds.Build do
       :cancelled,
       :expired
     ])
-    |> unique_constraint([:version, :type, :content_source_id, :content_source_platform],
-      name: "builds_version_type_content_source_id_content_source_platform_i"
+    |> unique_constraint([:version, :type],
+      name: "builds_version_type_index"
     )
     |> assoc_constraint(:project)
   end

--- a/lib/glossia/builds/build_worker.ex
+++ b/lib/glossia/builds/build_worker.ex
@@ -58,10 +58,10 @@ defmodule Glossia.Builds.BuildWorker do
     build =
       Repo.insert!(Build.changeset(%Build{}, attrs))
 
-    content_source =
-      Glossia.ContentSources.content_source(String.to_atom(content_source_platform))
+    content_source_platform_module =
+      Glossia.ContentSources.get_platform_module(String.to_atom(content_source_platform))
 
-    content_source.update_state(
+    content_source_platform_module.update_state(
       id_in_content_source_platform,
       :pending,
       version,
@@ -102,7 +102,7 @@ defmodule Glossia.Builds.BuildWorker do
       end
     })
 
-    content_source.update_state(
+    content_source_platform_module.update_state(
       id_in_content_source_platform,
       :success,
       version,

--- a/lib/glossia/builds/build_worker.ex
+++ b/lib/glossia/builds/build_worker.ex
@@ -16,8 +16,8 @@ defmodule Glossia.Builds.BuildWorker do
           "project_id" => project_id,
           "type" => type,
           "version" => version,
-          "id_in_content_source_platform" => id_in_content_source_platform,
-          "content_source_platform" => content_source_platform,
+          "id_in_content_platform" => id_in_content_platform,
+          "content_platform" => content_platform,
           "project_handle" => project_handle,
           "account_handle" => account_handle
         }
@@ -33,8 +33,8 @@ defmodule Glossia.Builds.BuildWorker do
           project_id: project_id,
           project_handle: project_handle,
           account_handle: account_handle,
-          id_in_content_source_platform: id_in_content_source_platform,
-          content_source_platform: content_source_platform,
+          id_in_content_platform: id_in_content_platform,
+          content_platform: content_platform,
           content_source_access_token: content_source_access_token
         })
 
@@ -45,8 +45,8 @@ defmodule Glossia.Builds.BuildWorker do
 
   def trigger_build(
         %{
-          id_in_content_source_platform: id_in_content_source_platform,
-          content_source_platform: content_source_platform,
+          id_in_content_platform: id_in_content_platform,
+          content_platform: content_platform,
           version: version,
           access_token: access_token,
           content_source_access_token: content_source_access_token,
@@ -58,11 +58,11 @@ defmodule Glossia.Builds.BuildWorker do
     build =
       Repo.insert!(Build.changeset(%Build{}, attrs))
 
-    content_source_platform_module =
-      Glossia.ContentSources.get_platform_module(String.to_atom(content_source_platform))
+    content_platform_module =
+      Glossia.ContentSources.get_platform_module(String.to_atom(content_platform))
 
-    content_source_platform_module.update_state(
-      id_in_content_source_platform,
+    content_platform_module.update_state(
+      id_in_content_platform,
       :pending,
       version,
       target_url: "",
@@ -82,8 +82,8 @@ defmodule Glossia.Builds.BuildWorker do
         GLOSSIA_BUILD_VERSION: build.version,
 
         # Content Source
-        GLOSSIA_ID_IN_CONTENT_SOURCE_PLATFORM: id_in_content_source_platform,
-        GLOSSIA_CONTENT_SOURCE_PLATFORM: content_source_platform,
+        GLOSSIA_id_in_content_platform: id_in_content_platform,
+        GLOSSIA_content_platform: content_platform,
         GLOSSIA_CONTENT_SOURCE_ACCESS_TOKEN: content_source_access_token
       },
       update_status_cb: fn %{
@@ -102,8 +102,8 @@ defmodule Glossia.Builds.BuildWorker do
       end
     })
 
-    content_source_platform_module.update_state(
-      id_in_content_source_platform,
+    content_platform_module.update_state(
+      id_in_content_platform,
       :success,
       version,
       target_url: "",

--- a/lib/glossia/builds/build_worker.ex
+++ b/lib/glossia/builds/build_worker.ex
@@ -16,7 +16,7 @@ defmodule Glossia.Builds.BuildWorker do
           "project_id" => project_id,
           "type" => type,
           "version" => version,
-          "content_source_id" => content_source_id,
+          "id_in_content_source_platform" => id_in_content_source_platform,
           "content_source_platform" => content_source_platform,
           "project_handle" => project_handle,
           "account_handle" => account_handle
@@ -33,7 +33,7 @@ defmodule Glossia.Builds.BuildWorker do
           project_id: project_id,
           project_handle: project_handle,
           account_handle: account_handle,
-          content_source_id: content_source_id,
+          id_in_content_source_platform: id_in_content_source_platform,
           content_source_platform: content_source_platform,
           content_source_access_token: content_source_access_token
         })
@@ -45,7 +45,7 @@ defmodule Glossia.Builds.BuildWorker do
 
   def trigger_build(
         %{
-          content_source_id: content_source_id,
+          id_in_content_source_platform: id_in_content_source_platform,
           content_source_platform: content_source_platform,
           version: version,
           access_token: access_token,
@@ -62,7 +62,7 @@ defmodule Glossia.Builds.BuildWorker do
       Glossia.ContentSources.content_source(String.to_atom(content_source_platform))
 
     content_source.update_state(
-      content_source_id,
+      id_in_content_source_platform,
       :pending,
       version,
       target_url: "",
@@ -82,7 +82,7 @@ defmodule Glossia.Builds.BuildWorker do
         GLOSSIA_BUILD_VERSION: build.version,
 
         # Content Source
-        GLOSSIA_CONTENT_SOURCE_ID: content_source_id,
+        GLOSSIA_ID_IN_CONTENT_SOURCE_PLATFORM: id_in_content_source_platform,
         GLOSSIA_CONTENT_SOURCE_PLATFORM: content_source_platform,
         GLOSSIA_CONTENT_SOURCE_ACCESS_TOKEN: content_source_access_token
       },
@@ -103,7 +103,7 @@ defmodule Glossia.Builds.BuildWorker do
     })
 
     content_source.update_state(
-      content_source_id,
+      id_in_content_source_platform,
       :success,
       version,
       target_url: "",

--- a/lib/glossia/content_sources.ex
+++ b/lib/glossia/content_sources.ex
@@ -1,22 +1,23 @@
 defmodule Glossia.ContentSources do
   @moduledoc false
 
-  alias Glossia.ContentSources.GitHub
+  alias Glossia.ContentSources.Platforms.GitHub
 
   @doc ~S"""
-  Given a content source platform, it returns the module that represents it.
+  Given the atom representing a content source platform,
+  it returns the module that implements the content source platform.
   """
-  @spec content_source(platform :: atom()) :: module() | nil
-  def content_source(platform) do
-    content_sources()
-    |> Enum.find(fn {content_source_platform, _} -> content_source_platform == platform end)
+  @spec get_platform_module(platform :: atom()) :: module() | nil
+  def get_platform_module(platform) do
+    get_platform_modules()
+    |> Enum.find(fn {platform_id, _} -> platform_id == platform end)
     |> case do
       {_, module} -> module
       nil -> nil
     end
   end
 
-  defp content_sources() do
+  defp get_platform_modules() do
     [{:github, GitHub}]
   end
 end

--- a/lib/glossia/content_sources/platform.ex
+++ b/lib/glossia/content_sources/platform.ex
@@ -23,9 +23,10 @@ defmodule Glossia.ContentSources.Platform do
   It returns the versions of the project in the content source.
 
   ## Parameters
-  - `content_source_id` - The ID that represents the project in the content source platform.
+  - `id_in_content_source_platform` - The ID that represents the project in the content source platform.
   """
-  @callback get_versions(content_source_id :: String.t()) :: {:ok, [any()]} | {:error, any()}
+  @callback get_versions(id_in_content_source_platform :: String.t()) ::
+              {:ok, [any()]} | {:error, any()}
 
   @doc ~S"""
   Different content sources name versions differently. For example, in the case of GitHub,
@@ -38,26 +39,26 @@ defmodule Glossia.ContentSources.Platform do
   the most recent commit sha in the default branch.
 
   ## Parameters
-  - `content_source_id` - The id that represents the project in the content source platform.
+  - `id_in_content_source_platform` - The id that represents the project in the content source platform.
 
   ## Examples
 
       iex> Glossia.ContentSources.Platforms.GitHub.get_most_recent_version(github_content_source)
       {:ok, "6c325ef99cb6afa8d0cb87a565dc1f59ab46fb67"}
   """
-  @callback get_most_recent_version(content_source_id :: String.t()) ::
+  @callback get_most_recent_version(id_in_content_source_platform :: String.t()) ::
               {:ok, String.t()} | {:error, any()}
 
   @doc ~S"""
   It returns the content from a content source.
 
   ## Parameters
-  - `content_source_id` - The id that represents the project in the content source platform.
+  - `id_in_content_source_platform` - The id that represents the project in the content source platform.
   - `content_id` - The content id. What it refers to depends on the content source. For example, in the case of a Git repository is the path to the file.
   - `version` - The version of the content.
   """
   @callback get_content(
-              content_source_id :: String.t(),
+              id_in_content_source_platform :: String.t(),
               content_id :: String.t(),
               version :: String.t()
             ) ::
@@ -75,7 +76,7 @@ defmodule Glossia.ContentSources.Platform do
   and including the changes in it.
 
   # Parameters
-  - `content_source_id` - The id that represents the project in the content source platform.
+  - `id_in_content_source_platform` - The id that represents the project in the content source platform.
   - `opts` - The options to configure the updating of the content.
 
   ## Examples
@@ -90,7 +91,10 @@ defmodule Glossia.ContentSources.Platform do
     })
     {:ok, "6c325ef99cb6afa8d0cb87a565dc1f59ab46fb67"}
   """
-  @callback update_content(content_source_id :: String.t(), opts :: update_content_opts_t()) ::
+  @callback update_content(
+              id_in_content_source_platform :: String.t(),
+              opts :: update_content_opts_t()
+            ) ::
               {:ok, %{id: String.t(), url: String.t() | nil}}
               | {:error, any()}
               | {:error, :newer_version_exists}
@@ -103,7 +107,7 @@ defmodule Glossia.ContentSources.Platform do
   cancel running updates when new versions are available.
   """
   @callback get_content_branch_id(
-              content_source_id :: String.t(),
+              id_in_content_source_platform :: String.t(),
               opts :: get_content_branch_id_opts_t
             ) ::
               String.t()
@@ -114,7 +118,7 @@ defmodule Glossia.ContentSources.Platform do
   not trigger a localization.
 
   # Parameters
-  - `content_source_id` - The id that represents the project in the content source platform.
+  - `id_in_content_source_platform` - The id that represents the project in the content source platform.
   - `version` - The version of the content. For example, in the case of GitHub it represents the commit sha.
 
   # Example
@@ -122,7 +126,8 @@ defmodule Glossia.ContentSources.Platform do
       iex> Glossia.ContentSources.Platforms.GitHub.should_localize?("6c325ef99cb6afa8d0cb87a565dc1f59ab46fb67")
       false
   """
-  @callback should_localize?(content_source_id :: String.t(), version :: String.t()) :: boolean()
+  @callback should_localize?(id_in_content_source_platform :: String.t(), version :: String.t()) ::
+              boolean()
 
   @type update_status_t :: :error | :failure | :pending | :success
 
@@ -131,19 +136,20 @@ defmodule Glossia.ContentSources.Platform do
   it updates the status of a commit.
 
   # Parameters
-  - `content_source_id` - The id that represents the project in the content source platform.
+  - `id_in_content_source_platform` - The id that represents the project in the content source platform.
   - `state` - The state of the localization.
   - `version` - The version of the content. For example, in the case of GitHub it represents the commit sha.
   - `opts` - The options to configure the updating of the state.
   """
   @callback update_state(
-              content_source_id :: String.t(),
+              id_in_content_source_platform :: String.t(),
               state :: update_status_t(),
               version :: String.t(),
               opts :: [{:target_url, String.t() | nil}, {:description, String.t() | nil}]
             ) :: :ok | {:error, any()}
 
-  @callback generate_auth_token(content_source_id :: any()) :: {:ok, String.t()} | {:error, any()}
+  @callback generate_auth_token(id_in_content_source_platform :: any()) ::
+              {:ok, String.t()} | {:error, any()}
 
   @callback is_webhook_payload_valid?(
               req_headers :: Keyword.t(),

--- a/lib/glossia/content_sources/platform.ex
+++ b/lib/glossia/content_sources/platform.ex
@@ -23,9 +23,9 @@ defmodule Glossia.ContentSources.Platform do
   It returns the versions of the project in the content source.
 
   ## Parameters
-  - `id_in_content_source_platform` - The ID that represents the project in the content source platform.
+  - `id_in_content_platform` - The ID that represents the project in the content source platform.
   """
-  @callback get_versions(id_in_content_source_platform :: String.t()) ::
+  @callback get_versions(id_in_content_platform :: String.t()) ::
               {:ok, [any()]} | {:error, any()}
 
   @doc ~S"""
@@ -39,26 +39,26 @@ defmodule Glossia.ContentSources.Platform do
   the most recent commit sha in the default branch.
 
   ## Parameters
-  - `id_in_content_source_platform` - The id that represents the project in the content source platform.
+  - `id_in_content_platform` - The id that represents the project in the content source platform.
 
   ## Examples
 
       iex> Glossia.ContentSources.Platforms.GitHub.get_most_recent_version(github_content_source)
       {:ok, "6c325ef99cb6afa8d0cb87a565dc1f59ab46fb67"}
   """
-  @callback get_most_recent_version(id_in_content_source_platform :: String.t()) ::
+  @callback get_most_recent_version(id_in_content_platform :: String.t()) ::
               {:ok, String.t()} | {:error, any()}
 
   @doc ~S"""
   It returns the content from a content source.
 
   ## Parameters
-  - `id_in_content_source_platform` - The id that represents the project in the content source platform.
+  - `id_in_content_platform` - The id that represents the project in the content source platform.
   - `content_id` - The content id. What it refers to depends on the content source. For example, in the case of a Git repository is the path to the file.
   - `version` - The version of the content.
   """
   @callback get_content(
-              id_in_content_source_platform :: String.t(),
+              id_in_content_platform :: String.t(),
               content_id :: String.t(),
               version :: String.t()
             ) ::
@@ -76,7 +76,7 @@ defmodule Glossia.ContentSources.Platform do
   and including the changes in it.
 
   # Parameters
-  - `id_in_content_source_platform` - The id that represents the project in the content source platform.
+  - `id_in_content_platform` - The id that represents the project in the content source platform.
   - `opts` - The options to configure the updating of the content.
 
   ## Examples
@@ -92,7 +92,7 @@ defmodule Glossia.ContentSources.Platform do
     {:ok, "6c325ef99cb6afa8d0cb87a565dc1f59ab46fb67"}
   """
   @callback update_content(
-              id_in_content_source_platform :: String.t(),
+              id_in_content_platform :: String.t(),
               opts :: update_content_opts_t()
             ) ::
               {:ok, %{id: String.t(), url: String.t() | nil}}
@@ -107,7 +107,7 @@ defmodule Glossia.ContentSources.Platform do
   cancel running updates when new versions are available.
   """
   @callback get_content_branch_id(
-              id_in_content_source_platform :: String.t(),
+              id_in_content_platform :: String.t(),
               opts :: get_content_branch_id_opts_t
             ) ::
               String.t()
@@ -118,7 +118,7 @@ defmodule Glossia.ContentSources.Platform do
   not trigger a localization.
 
   # Parameters
-  - `id_in_content_source_platform` - The id that represents the project in the content source platform.
+  - `id_in_content_platform` - The id that represents the project in the content source platform.
   - `version` - The version of the content. For example, in the case of GitHub it represents the commit sha.
 
   # Example
@@ -126,7 +126,7 @@ defmodule Glossia.ContentSources.Platform do
       iex> Glossia.ContentSources.Platforms.GitHub.should_localize?("6c325ef99cb6afa8d0cb87a565dc1f59ab46fb67")
       false
   """
-  @callback should_localize?(id_in_content_source_platform :: String.t(), version :: String.t()) ::
+  @callback should_localize?(id_in_content_platform :: String.t(), version :: String.t()) ::
               boolean()
 
   @type update_status_t :: :error | :failure | :pending | :success
@@ -136,19 +136,19 @@ defmodule Glossia.ContentSources.Platform do
   it updates the status of a commit.
 
   # Parameters
-  - `id_in_content_source_platform` - The id that represents the project in the content source platform.
+  - `id_in_content_platform` - The id that represents the project in the content source platform.
   - `state` - The state of the localization.
   - `version` - The version of the content. For example, in the case of GitHub it represents the commit sha.
   - `opts` - The options to configure the updating of the state.
   """
   @callback update_state(
-              id_in_content_source_platform :: String.t(),
+              id_in_content_platform :: String.t(),
               state :: update_status_t(),
               version :: String.t(),
               opts :: [{:target_url, String.t() | nil}, {:description, String.t() | nil}]
             ) :: :ok | {:error, any()}
 
-  @callback generate_auth_token(id_in_content_source_platform :: any()) ::
+  @callback generate_auth_token(id_in_content_platform :: any()) ::
               {:ok, String.t()} | {:error, any()}
 
   @callback is_webhook_payload_valid?(

--- a/lib/glossia/content_sources/platform.ex
+++ b/lib/glossia/content_sources/platform.ex
@@ -1,4 +1,4 @@
-defmodule Glossia.ContentSources.ContentSource do
+defmodule Glossia.ContentSources.Platform do
   @moduledoc ~S"""
   This module defines the behaviour of a content source. A content source is a platform
   that Glossia can establish a CRUD interface with to localize content. To understand this
@@ -42,7 +42,7 @@ defmodule Glossia.ContentSources.ContentSource do
 
   ## Examples
 
-      iex> Glossia.ContentSources.GitHub.get_most_recent_version(github_content_source)
+      iex> Glossia.ContentSources.Platforms.GitHub.get_most_recent_version(github_content_source)
       {:ok, "6c325ef99cb6afa8d0cb87a565dc1f59ab46fb67"}
   """
   @callback get_most_recent_version(content_source_id :: String.t()) ::
@@ -80,7 +80,7 @@ defmodule Glossia.ContentSources.ContentSource do
 
   ## Examples
 
-    iex> Glossia.ContentSources.GitHub.update_content(github_content_source, %{
+    iex> Glossia.ContentSources.Platforms.GitHub.update_content(github_content_source, %{
       title: "My new title",
       description: "My new description",
       version: "6c325ef99cb6afa8d0cb87a565dc1f59ab46fb67",
@@ -119,7 +119,7 @@ defmodule Glossia.ContentSources.ContentSource do
 
   # Example
 
-      iex> Glossia.ContentSources.GitHub.should_localize?("6c325ef99cb6afa8d0cb87a565dc1f59ab46fb67")
+      iex> Glossia.ContentSources.Platforms.GitHub.should_localize?("6c325ef99cb6afa8d0cb87a565dc1f59ab46fb67")
       false
   """
   @callback should_localize?(content_source_id :: String.t(), version :: String.t()) :: boolean()

--- a/lib/glossia/content_sources/platforms/github.ex
+++ b/lib/glossia/content_sources/platforms/github.ex
@@ -18,8 +18,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def get_content(id_in_content_source_platform, file_path, commit_sha) do
-    {client, owner, repo} = get_client_owner_and_repo(id_in_content_source_platform)
+  def get_content(id_in_content_platform, file_path, commit_sha) do
+    {client, owner, repo} = get_client_owner_and_repo(id_in_content_platform)
 
     Logger.debug("Fetching the content of a file", %{
       owner: owner,
@@ -44,8 +44,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
     end
   end
 
-  defp send_graphql_query(id_in_content_source_platform, query, variables \\ %{}) do
-    {access_token, owner, repo} = get_access_token_owner_and_repo(id_in_content_source_platform)
+  defp send_graphql_query(id_in_content_platform, query, variables \\ %{}) do
+    {access_token, owner, repo} = get_access_token_owner_and_repo(id_in_content_platform)
     variables = variables |> Map.merge(%{"owner" => owner, "repo" => repo})
 
     body = %{
@@ -66,15 +66,15 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def get_most_recent_version(id_in_content_source_platform) do
-    {owner, repo} = get_owner_and_repo(id_in_content_source_platform)
-    {:ok, branch} = get_default_branch(id_in_content_source_platform)
+  def get_most_recent_version(id_in_content_platform) do
+    {owner, repo} = get_owner_and_repo(id_in_content_platform)
+    {:ok, branch} = get_default_branch(id_in_content_platform)
 
     Logger.debug("Fetching the most recent version", %{owner: owner, repo: repo})
 
     response =
       send_graphql_query(
-        id_in_content_source_platform,
+        id_in_content_platform,
         """
         query getMostRecentCommit($owner: String!, $repo: String!) {
           repository(owner: $owner, name: $repo) {
@@ -125,7 +125,7 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
 
   @impl Glossia.ContentSources.Platform
   def update_content(
-        _id_in_content_source_platform,
+        _id_in_content_platform,
         %{
           content: []
         }
@@ -135,7 +135,7 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
 
   @impl Glossia.ContentSources.Platform
   def update_content(
-        id_in_content_source_platform,
+        id_in_content_platform,
         %{
           title: commit_title,
           description: commit_description,
@@ -143,7 +143,7 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
           content: content
         } = opts
       ) do
-    {client, owner, repo} = get_client_owner_and_repo(id_in_content_source_platform)
+    {client, owner, repo} = get_client_owner_and_repo(id_in_content_platform)
 
     Logger.debug(
       "Updating the content",
@@ -198,8 +198,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def get_content_branch_id(id_in_content_source_platform, %{version: commit_sha} = opts) do
-    {client, owner, repo} = get_client_owner_and_repo(id_in_content_source_platform)
+  def get_content_branch_id(id_in_content_platform, %{version: commit_sha} = opts) do
+    {client, owner, repo} = get_client_owner_and_repo(id_in_content_platform)
 
     Logger.debug(
       "Getting the branch id",
@@ -222,8 +222,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def should_localize?(id_in_content_source_platform, commit_sha) do
-    {client, owner, repo} = get_client_owner_and_repo(id_in_content_source_platform)
+  def should_localize?(id_in_content_platform, commit_sha) do
+    {client, owner, repo} = get_client_owner_and_repo(id_in_content_platform)
 
     Logger.debug(
       "Checking if the commit with the sha #{commit_sha} should be localized",
@@ -241,8 +241,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def update_state(id_in_content_source_platform, state, commit_sha, opts \\ []) do
-    {client, owner, repo} = get_client_owner_and_repo(id_in_content_source_platform)
+  def update_state(id_in_content_platform, state, commit_sha, opts \\ []) do
+    {client, owner, repo} = get_client_owner_and_repo(id_in_content_platform)
 
     Logger.debug(
       "Updating the state for commit #{commit_sha} to #{state}",
@@ -274,8 +274,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def generate_auth_token(id_in_content_source_platform) do
-    {owner, repo} = get_owner_and_repo(id_in_content_source_platform)
+  def generate_auth_token(id_in_content_platform) do
+    {owner, repo} = get_owner_and_repo(id_in_content_platform)
 
     Logger.debug(
       "Generating an auth token for the repo",
@@ -315,14 +315,14 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def get_versions(id_in_content_source_platform) do
-    {owner, repo} = get_owner_and_repo(id_in_content_source_platform)
-    {:ok, branch} = get_default_branch(id_in_content_source_platform)
+  def get_versions(id_in_content_platform) do
+    {owner, repo} = get_owner_and_repo(id_in_content_platform)
+    {:ok, branch} = get_default_branch(id_in_content_platform)
     Logger.debug("Fetching the most recent version", %{owner: owner, repo: repo})
 
     response =
       send_graphql_query(
-        id_in_content_source_platform,
+        id_in_content_platform,
         """
         query getMostRecentCommit($owner: String!, $repo: String!) {
           repository(owner: $owner, name: $repo) {
@@ -392,27 +392,27 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
     access_token
   end
 
-  defp get_owner_and_repo(id_in_content_source_platform) do
-    [owner, repo] = id_in_content_source_platform |> String.split("/")
+  defp get_owner_and_repo(id_in_content_platform) do
+    [owner, repo] = id_in_content_platform |> String.split("/")
     {owner, repo}
   end
 
-  defp get_access_token_owner_and_repo(id_in_content_source_platform) do
+  defp get_access_token_owner_and_repo(id_in_content_platform) do
     app_jwt_token = Glossia.GitHub.AppToken.generate_and_sign!()
 
     {200, %{"id" => installation_id}, _} =
       Tentacat.get(
-        "repos/#{id_in_content_source_platform}/installation",
+        "repos/#{id_in_content_platform}/installation",
         Tentacat.Client.new(%{jwt: app_jwt_token})
       )
 
-    {owner, repo} = get_owner_and_repo(id_in_content_source_platform)
+    {owner, repo} = get_owner_and_repo(id_in_content_platform)
     access_token = get_access_token_for_installation(installation_id, app_jwt_token)
     {access_token, owner, repo}
   end
 
-  defp get_client_owner_and_repo(id_in_content_source_platform) do
-    {access_token, owner, repo} = get_access_token_owner_and_repo(id_in_content_source_platform)
+  defp get_client_owner_and_repo(id_in_content_platform) do
+    {access_token, owner, repo} = get_access_token_owner_and_repo(id_in_content_platform)
     client = %{access_token: access_token} |> Tentacat.Client.new()
     {client, owner, repo}
   end
@@ -446,12 +446,12 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
     {:ok, :crypto.mac(:hmac, :sha, app_secret, payload) |> Base.encode16(case: :lower)}
   end
 
-  def get_default_branch(id_in_content_source_platform) do
-    {owner, repo} = get_owner_and_repo(id_in_content_source_platform)
+  def get_default_branch(id_in_content_platform) do
+    {owner, repo} = get_owner_and_repo(id_in_content_platform)
 
     response =
       send_graphql_query(
-        id_in_content_source_platform,
+        id_in_content_platform,
         """
         query GetRepositoryDefaultBranch($owner: String!, $repo: String!) {
           repository(owner: $owner, name: $repo) {

--- a/lib/glossia/content_sources/platforms/github.ex
+++ b/lib/glossia/content_sources/platforms/github.ex
@@ -1,23 +1,23 @@
-defmodule Glossia.ContentSources.GitHub do
+defmodule Glossia.ContentSources.Platforms.GitHub do
   @moduledoc false
 
   require Logger
 
-  @behaviour Glossia.ContentSources.ContentSource
+  @behaviour Glossia.ContentSources.Platform
 
-  # Glossia.ContentSources.ContentSource behavior
+  # Glossia.ContentSources.Platform behavior
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def supports_versioning?() do
     true
   end
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def version_term() do
     "commit"
   end
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def get_content(content_source_id, file_path, commit_sha) do
     {client, owner, repo} = get_client_owner_and_repo(content_source_id)
 
@@ -65,7 +65,7 @@ defmodule Glossia.ContentSources.GitHub do
     end
   end
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def get_most_recent_version(content_source_id) do
     {owner, repo} = get_owner_and_repo(content_source_id)
     {:ok, branch} = get_default_branch(content_source_id)
@@ -123,7 +123,7 @@ defmodule Glossia.ContentSources.GitHub do
     end
   end
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def update_content(
         _content_source_id,
         %{
@@ -133,7 +133,7 @@ defmodule Glossia.ContentSources.GitHub do
     # Noop
   end
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def update_content(
         content_source_id,
         %{
@@ -197,7 +197,7 @@ defmodule Glossia.ContentSources.GitHub do
     end
   end
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def get_content_branch_id(content_source_id, %{version: commit_sha} = opts) do
     {client, owner, repo} = get_client_owner_and_repo(content_source_id)
 
@@ -221,7 +221,7 @@ defmodule Glossia.ContentSources.GitHub do
     end
   end
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def should_localize?(content_source_id, commit_sha) do
     {client, owner, repo} = get_client_owner_and_repo(content_source_id)
 
@@ -240,7 +240,7 @@ defmodule Glossia.ContentSources.GitHub do
     end
   end
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def update_state(content_source_id, state, commit_sha, opts \\ []) do
     {client, owner, repo} = get_client_owner_and_repo(content_source_id)
 
@@ -273,7 +273,7 @@ defmodule Glossia.ContentSources.GitHub do
     end
   end
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def generate_auth_token(content_source_id) do
     {owner, repo} = get_owner_and_repo(content_source_id)
 
@@ -303,10 +303,7 @@ defmodule Glossia.ContentSources.GitHub do
     end
   end
 
-  @doc ~S"""
-  Given the request headers and the payload it validates the payload signature.
-  """
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def is_webhook_payload_valid?(req_headers, payload) do
     case signature_from_req_headers(req_headers) do
       nil ->
@@ -317,7 +314,7 @@ defmodule Glossia.ContentSources.GitHub do
     end
   end
 
-  @impl Glossia.ContentSources.ContentSource
+  @impl Glossia.ContentSources.Platform
   def get_versions(content_source_id) do
     {owner, repo} = get_owner_and_repo(content_source_id)
     {:ok, branch} = get_default_branch(content_source_id)

--- a/lib/glossia/content_sources/platforms/github.ex
+++ b/lib/glossia/content_sources/platforms/github.ex
@@ -18,8 +18,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def get_content(content_source_id, file_path, commit_sha) do
-    {client, owner, repo} = get_client_owner_and_repo(content_source_id)
+  def get_content(id_in_content_source_platform, file_path, commit_sha) do
+    {client, owner, repo} = get_client_owner_and_repo(id_in_content_source_platform)
 
     Logger.debug("Fetching the content of a file", %{
       owner: owner,
@@ -44,8 +44,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
     end
   end
 
-  defp send_graphql_query(content_source_id, query, variables \\ %{}) do
-    {access_token, owner, repo} = get_access_token_owner_and_repo(content_source_id)
+  defp send_graphql_query(id_in_content_source_platform, query, variables \\ %{}) do
+    {access_token, owner, repo} = get_access_token_owner_and_repo(id_in_content_source_platform)
     variables = variables |> Map.merge(%{"owner" => owner, "repo" => repo})
 
     body = %{
@@ -66,15 +66,15 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def get_most_recent_version(content_source_id) do
-    {owner, repo} = get_owner_and_repo(content_source_id)
-    {:ok, branch} = get_default_branch(content_source_id)
+  def get_most_recent_version(id_in_content_source_platform) do
+    {owner, repo} = get_owner_and_repo(id_in_content_source_platform)
+    {:ok, branch} = get_default_branch(id_in_content_source_platform)
 
     Logger.debug("Fetching the most recent version", %{owner: owner, repo: repo})
 
     response =
       send_graphql_query(
-        content_source_id,
+        id_in_content_source_platform,
         """
         query getMostRecentCommit($owner: String!, $repo: String!) {
           repository(owner: $owner, name: $repo) {
@@ -125,7 +125,7 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
 
   @impl Glossia.ContentSources.Platform
   def update_content(
-        _content_source_id,
+        _id_in_content_source_platform,
         %{
           content: []
         }
@@ -135,7 +135,7 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
 
   @impl Glossia.ContentSources.Platform
   def update_content(
-        content_source_id,
+        id_in_content_source_platform,
         %{
           title: commit_title,
           description: commit_description,
@@ -143,7 +143,7 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
           content: content
         } = opts
       ) do
-    {client, owner, repo} = get_client_owner_and_repo(content_source_id)
+    {client, owner, repo} = get_client_owner_and_repo(id_in_content_source_platform)
 
     Logger.debug(
       "Updating the content",
@@ -198,8 +198,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def get_content_branch_id(content_source_id, %{version: commit_sha} = opts) do
-    {client, owner, repo} = get_client_owner_and_repo(content_source_id)
+  def get_content_branch_id(id_in_content_source_platform, %{version: commit_sha} = opts) do
+    {client, owner, repo} = get_client_owner_and_repo(id_in_content_source_platform)
 
     Logger.debug(
       "Getting the branch id",
@@ -222,8 +222,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def should_localize?(content_source_id, commit_sha) do
-    {client, owner, repo} = get_client_owner_and_repo(content_source_id)
+  def should_localize?(id_in_content_source_platform, commit_sha) do
+    {client, owner, repo} = get_client_owner_and_repo(id_in_content_source_platform)
 
     Logger.debug(
       "Checking if the commit with the sha #{commit_sha} should be localized",
@@ -241,8 +241,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def update_state(content_source_id, state, commit_sha, opts \\ []) do
-    {client, owner, repo} = get_client_owner_and_repo(content_source_id)
+  def update_state(id_in_content_source_platform, state, commit_sha, opts \\ []) do
+    {client, owner, repo} = get_client_owner_and_repo(id_in_content_source_platform)
 
     Logger.debug(
       "Updating the state for commit #{commit_sha} to #{state}",
@@ -274,8 +274,8 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def generate_auth_token(content_source_id) do
-    {owner, repo} = get_owner_and_repo(content_source_id)
+  def generate_auth_token(id_in_content_source_platform) do
+    {owner, repo} = get_owner_and_repo(id_in_content_source_platform)
 
     Logger.debug(
       "Generating an auth token for the repo",
@@ -315,14 +315,14 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
   end
 
   @impl Glossia.ContentSources.Platform
-  def get_versions(content_source_id) do
-    {owner, repo} = get_owner_and_repo(content_source_id)
-    {:ok, branch} = get_default_branch(content_source_id)
+  def get_versions(id_in_content_source_platform) do
+    {owner, repo} = get_owner_and_repo(id_in_content_source_platform)
+    {:ok, branch} = get_default_branch(id_in_content_source_platform)
     Logger.debug("Fetching the most recent version", %{owner: owner, repo: repo})
 
     response =
       send_graphql_query(
-        content_source_id,
+        id_in_content_source_platform,
         """
         query getMostRecentCommit($owner: String!, $repo: String!) {
           repository(owner: $owner, name: $repo) {
@@ -392,27 +392,27 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
     access_token
   end
 
-  defp get_owner_and_repo(content_source_id) do
-    [owner, repo] = content_source_id |> String.split("/")
+  defp get_owner_and_repo(id_in_content_source_platform) do
+    [owner, repo] = id_in_content_source_platform |> String.split("/")
     {owner, repo}
   end
 
-  defp get_access_token_owner_and_repo(content_source_id) do
+  defp get_access_token_owner_and_repo(id_in_content_source_platform) do
     app_jwt_token = Glossia.GitHub.AppToken.generate_and_sign!()
 
     {200, %{"id" => installation_id}, _} =
       Tentacat.get(
-        "repos/#{content_source_id}/installation",
+        "repos/#{id_in_content_source_platform}/installation",
         Tentacat.Client.new(%{jwt: app_jwt_token})
       )
 
-    {owner, repo} = get_owner_and_repo(content_source_id)
+    {owner, repo} = get_owner_and_repo(id_in_content_source_platform)
     access_token = get_access_token_for_installation(installation_id, app_jwt_token)
     {access_token, owner, repo}
   end
 
-  defp get_client_owner_and_repo(content_source_id) do
-    {access_token, owner, repo} = get_access_token_owner_and_repo(content_source_id)
+  defp get_client_owner_and_repo(id_in_content_source_platform) do
+    {access_token, owner, repo} = get_access_token_owner_and_repo(id_in_content_source_platform)
     client = %{access_token: access_token} |> Tentacat.Client.new()
     {client, owner, repo}
   end
@@ -446,12 +446,12 @@ defmodule Glossia.ContentSources.Platforms.GitHub do
     {:ok, :crypto.mac(:hmac, :sha, app_secret, payload) |> Base.encode16(case: :lower)}
   end
 
-  def get_default_branch(content_source_id) do
-    {owner, repo} = get_owner_and_repo(content_source_id)
+  def get_default_branch(id_in_content_source_platform) do
+    {owner, repo} = get_owner_and_repo(id_in_content_source_platform)
 
     response =
       send_graphql_query(
-        content_source_id,
+        id_in_content_source_platform,
         """
         query GetRepositoryDefaultBranch($owner: String!, $repo: String!) {
           repository(owner: $owner, name: $repo) {

--- a/lib/glossia/localizations.ex
+++ b/lib/glossia/localizations.ex
@@ -24,12 +24,16 @@ defmodule Glossia.Localizations do
   def process_localization(localization, %{project_id: project_id} = _opts) do
     project = Projects.find_project_by_id(project_id)
 
-    content_source = Glossia.ContentSources.content_source(project.content_source_platform)
+    content_source_platform_module =
+      Glossia.ContentSources.get_platform_module(project.content_source_platform)
 
     version = localization.version
 
     unique_id =
-      case content_source.get_content_branch_id(project.content_source_id, %{version: version}) do
+      case content_source_platform_module.get_content_branch_id(
+             project.id_in_content_source_platform,
+             %{version: version}
+           ) do
         nil -> version
         id -> id
       end

--- a/lib/glossia/localizations.ex
+++ b/lib/glossia/localizations.ex
@@ -24,14 +24,14 @@ defmodule Glossia.Localizations do
   def process_localization(localization, %{project_id: project_id} = _opts) do
     project = Projects.find_project_by_id(project_id)
 
-    content_source_platform_module =
-      Glossia.ContentSources.get_platform_module(project.content_source_platform)
+    content_platform_module =
+      Glossia.ContentSources.get_platform_module(project.content_platform)
 
     version = localization.version
 
     unique_id =
-      case content_source_platform_module.get_content_branch_id(
-             project.id_in_content_source_platform,
+      case content_platform_module.get_content_branch_id(
+             project.id_in_content_platform,
              %{version: version}
            ) do
         nil -> version

--- a/lib/glossia/localizations/utilities/localizer.ex
+++ b/lib/glossia/localizations/utilities/localizer.ex
@@ -9,13 +9,13 @@ defmodule Glossia.Localizations.Utilities.Localizer do
 
   @task_timeout 120_000
 
-  def localize(content_source, id_in_content_source_platform, version, content_changes) do
+  def localize(content_source_platform_module, id_in_content_source_platform, version, content_changes) do
     updates =
       content_changes
       |> Enum.map(fn module ->
         Task.Supervisor.async(Glossia.TaskSupervisor, fn ->
           __MODULE__.localize_module(
-            content_source,
+            content_source_platform_module,
             id_in_content_source_platform,
             module,
             version
@@ -60,9 +60,9 @@ defmodule Glossia.Localizations.Utilities.Localizer do
     {extracted_title, extracted_description}
   end
 
-  def localize_module(content_source, id_in_content_source_platform, module, version) do
+  def localize_module(content_source_platform_module, id_in_content_source_platform, module, version) do
     {:ok, source_content} =
-      content_source.get_content(
+      content_source_platform_module.get_content(
         id_in_content_source_platform,
         module[:source][:id],
         version

--- a/lib/glossia/localizations/utilities/localizer.ex
+++ b/lib/glossia/localizations/utilities/localizer.ex
@@ -9,14 +9,14 @@ defmodule Glossia.Localizations.Utilities.Localizer do
 
   @task_timeout 120_000
 
-  def localize(content_source_platform_module, id_in_content_source_platform, version, content_changes) do
+  def localize(content_platform_module, id_in_content_platform, version, content_changes) do
     updates =
       content_changes
       |> Enum.map(fn module ->
         Task.Supervisor.async(Glossia.TaskSupervisor, fn ->
           __MODULE__.localize_module(
-            content_source_platform_module,
-            id_in_content_source_platform,
+            content_platform_module,
+            id_in_content_platform,
             module,
             version
           )
@@ -60,10 +60,10 @@ defmodule Glossia.Localizations.Utilities.Localizer do
     {extracted_title, extracted_description}
   end
 
-  def localize_module(content_source_platform_module, id_in_content_source_platform, module, version) do
+  def localize_module(content_platform_module, id_in_content_platform, module, version) do
     {:ok, source_content} =
-      content_source_platform_module.get_content(
-        id_in_content_source_platform,
+      content_platform_module.get_content(
+        id_in_content_platform,
         module[:source][:id],
         version
       )

--- a/lib/glossia/localizations/utilities/localizer.ex
+++ b/lib/glossia/localizations/utilities/localizer.ex
@@ -9,12 +9,17 @@ defmodule Glossia.Localizations.Utilities.Localizer do
 
   @task_timeout 120_000
 
-  def localize(content_source, content_source_id, version, content_changes) do
+  def localize(content_source, id_in_content_source_platform, version, content_changes) do
     updates =
       content_changes
       |> Enum.map(fn module ->
         Task.Supervisor.async(Glossia.TaskSupervisor, fn ->
-          __MODULE__.localize_module(content_source, content_source_id, module, version)
+          __MODULE__.localize_module(
+            content_source,
+            id_in_content_source_platform,
+            module,
+            version
+          )
         end)
       end)
       |> Enum.map(fn task ->
@@ -55,10 +60,10 @@ defmodule Glossia.Localizations.Utilities.Localizer do
     {extracted_title, extracted_description}
   end
 
-  def localize_module(content_source, content_source_id, module, version) do
+  def localize_module(content_source, id_in_content_source_platform, module, version) do
     {:ok, source_content} =
       content_source.get_content(
-        content_source_id,
+        id_in_content_source_platform,
         module[:source][:id],
         version
       )

--- a/lib/glossia/localizations/workers/localize_worker.ex
+++ b/lib/glossia/localizations/workers/localize_worker.ex
@@ -16,15 +16,15 @@ defmodule Glossia.Localizations.Workers.LocalizeWorker do
     version = localization[:version]
     project = Projects.find_project_by_id(job.args["project_id"])
 
-    content_source_platform_module =
-      Glossia.ContentSources.get_platform_module(project.content_source_platform)
+    content_platform_module =
+      Glossia.ContentSources.get_platform_module(project.content_platform)
 
     content_changes = Parser.parse_localization(localization)
 
     _content_updates =
       Localizer.localize(
-        content_source_platform_module,
-        project.id_in_content_source_platform,
+        content_platform_module,
+        project.id_in_content_platform,
         version,
         content_changes
       )

--- a/lib/glossia/localizations/workers/localize_worker.ex
+++ b/lib/glossia/localizations/workers/localize_worker.ex
@@ -19,11 +19,15 @@ defmodule Glossia.Localizations.Workers.LocalizeWorker do
     content_source =
       Glossia.ContentSources.content_source(project.content_source_platform)
 
-    # project.content_source_id
     content_changes = Parser.parse_localization(localization)
 
     _content_updates =
-      Localizer.localize(content_source, project.content_source_id, version, content_changes)
+      Localizer.localize(
+        content_source,
+        project.id_in_content_source_platform,
+        version,
+        content_changes
+      )
 
     :ok
     # content_source

--- a/lib/glossia/localizations/workers/localize_worker.ex
+++ b/lib/glossia/localizations/workers/localize_worker.ex
@@ -16,14 +16,14 @@ defmodule Glossia.Localizations.Workers.LocalizeWorker do
     version = localization[:version]
     project = Projects.find_project_by_id(job.args["project_id"])
 
-    content_source =
-      Glossia.ContentSources.content_source(project.content_source_platform)
+    content_source_platform_module =
+      Glossia.ContentSources.get_platform_module(project.content_source_platform)
 
     content_changes = Parser.parse_localization(localization)
 
     _content_updates =
       Localizer.localize(
-        content_source,
+        content_source_platform_module,
         project.id_in_content_source_platform,
         version,
         content_changes

--- a/lib/glossia/projects.ex
+++ b/lib/glossia/projects.ex
@@ -26,18 +26,18 @@ defmodule Glossia.Projects do
       ) do
     project = project |> Repo.preload(:account)
 
-    content_source_platform_module =
-      Glossia.ContentSources.get_platform_module(project.content_source_platform)
+    content_platform_module =
+      Glossia.ContentSources.get_platform_module(project.content_platform)
 
     {:ok, access_token} =
-      content_source_platform_module.generate_auth_token(project.id_in_content_source_platform)
+      content_platform_module.generate_auth_token(project.id_in_content_platform)
 
     :ok =
       %{
         type: "new_version",
         version: version,
-        id_in_content_source_platform: project.id_in_content_source_platform,
-        content_source_platform: project.content_source_platform,
+        id_in_content_platform: project.id_in_content_platform,
+        content_platform: project.content_platform,
         project_id: project.id,
         project_handle: project.handle,
         account_handle: project.account.handle

--- a/lib/glossia/projects.ex
+++ b/lib/glossia/projects.ex
@@ -26,16 +26,17 @@ defmodule Glossia.Projects do
       ) do
     project = project |> Repo.preload(:account)
 
-    content_source =
-      Glossia.ContentSources.content_source(project.content_source_platform)
+    content_source_platform_module =
+      Glossia.ContentSources.get_platform_module(project.content_source_platform)
 
-    {:ok, access_token} = content_source.generate_auth_token(project.content_source_id)
+    {:ok, access_token} =
+      content_source_platform_module.generate_auth_token(project.id_in_content_source_platform)
 
     :ok =
       %{
         type: "new_version",
         version: version,
-        content_source_id: project.content_source_id,
+        id_in_content_source_platform: project.id_in_content_source_platform,
         content_source_platform: project.content_source_platform,
         project_id: project.id,
         project_handle: project.handle,

--- a/lib/glossia/projects/project.ex
+++ b/lib/glossia/projects/project.ex
@@ -11,7 +11,7 @@ defmodule Glossia.Projects.Project do
           handle: String.t(),
           account: Account.t() | nil,
           visibility: visibility(),
-          content_source_id: String.t(),
+          id_in_content_source_platform: String.t(),
           content_source_platform: content_source_platform()
         }
   @type visibility :: :public | :private
@@ -29,7 +29,7 @@ defmodule Glossia.Projects.Project do
 
   schema "projects" do
     field :handle, :string
-    field :content_source_id, :string
+    field :id_in_content_source_platform, :string
     field :content_source_platform, Ecto.Enum, values: [{:github, 1}]
     field :visibility, Ecto.Enum, values: [{:private, 1}, {:public, 2}]
     belongs_to :account, Account, on_replace: :raise
@@ -48,7 +48,7 @@ defmodule Glossia.Projects.Project do
     project
     |> cast(attrs, [
       :handle,
-      :content_source_id,
+      :id_in_content_source_platform,
       :content_source_platform,
       :account_id,
       :visibility
@@ -56,7 +56,7 @@ defmodule Glossia.Projects.Project do
     |> validate_required(
       [
         :handle,
-        :content_source_id,
+        :id_in_content_source_platform,
         :content_source_platform,
         :account_id
       ],
@@ -72,7 +72,7 @@ defmodule Glossia.Projects.Project do
     |> unique_constraint([:handle, :account_id],
       message: "There's already a project with the same handle"
     )
-    |> unique_constraint([:content_source_id, :content_source_platform],
+    |> unique_constraint([:id_in_content_source_platform, :content_source_platform],
       message: "There's already a project with the same repository"
     )
     |> assoc_constraint(:account)
@@ -82,11 +82,11 @@ defmodule Glossia.Projects.Project do
 
   def find_project_by_repository_query(%{
         content_source_platform: content_source_platform,
-        content_source_id: content_source_id
+        id_in_content_source_platform: id_in_content_source_platform
       }) do
     from(p in __MODULE__,
       where:
-        p.content_source_id == ^content_source_id and
+        p.id_in_content_source_platform == ^id_in_content_source_platform and
           p.content_source_platform == ^content_source_platform
     )
   end

--- a/lib/glossia/projects/project.ex
+++ b/lib/glossia/projects/project.ex
@@ -11,11 +11,11 @@ defmodule Glossia.Projects.Project do
           handle: String.t(),
           account: Account.t() | nil,
           visibility: visibility(),
-          id_in_content_source_platform: String.t(),
-          content_source_platform: content_source_platform()
+          id_in_content_platform: String.t(),
+          content_platform: content_platform()
         }
   @type visibility :: :public | :private
-  @type content_source_platform :: :github
+  @type content_platform :: :github
 
   # Module dependencies
 
@@ -29,8 +29,8 @@ defmodule Glossia.Projects.Project do
 
   schema "projects" do
     field :handle, :string
-    field :id_in_content_source_platform, :string
-    field :content_source_platform, Ecto.Enum, values: [{:github, 1}]
+    field :id_in_content_platform, :string
+    field :content_platform, Ecto.Enum, values: [{:github, 1}]
     field :visibility, Ecto.Enum, values: [{:private, 1}, {:public, 2}]
     belongs_to :account, Account, on_replace: :raise
     has_many(:builds, Build)
@@ -48,21 +48,21 @@ defmodule Glossia.Projects.Project do
     project
     |> cast(attrs, [
       :handle,
-      :id_in_content_source_platform,
-      :content_source_platform,
+      :id_in_content_platform,
+      :content_platform,
       :account_id,
       :visibility
     ])
     |> validate_required(
       [
         :handle,
-        :id_in_content_source_platform,
-        :content_source_platform,
+        :id_in_content_platform,
+        :content_platform,
         :account_id
       ],
       message: "This attribute is required"
     )
-    |> validate_inclusion(:content_source_platform, [:github])
+    |> validate_inclusion(:content_platform, [:github])
     |> validate_format(:handle, ~r/^[a-z0-9_]+$/i, message: "The handle must be alphanumeric")
     |> validate_length(:handle,
       min: 3,
@@ -72,7 +72,7 @@ defmodule Glossia.Projects.Project do
     |> unique_constraint([:handle, :account_id],
       message: "There's already a project with the same handle"
     )
-    |> unique_constraint([:id_in_content_source_platform, :content_source_platform],
+    |> unique_constraint([:id_in_content_platform, :content_platform],
       message: "There's already a project with the same repository"
     )
     |> assoc_constraint(:account)
@@ -81,13 +81,13 @@ defmodule Glossia.Projects.Project do
   # Queries
 
   def find_project_by_repository_query(%{
-        content_source_platform: content_source_platform,
-        id_in_content_source_platform: id_in_content_source_platform
+        content_platform: content_platform,
+        id_in_content_platform: id_in_content_platform
       }) do
     from(p in __MODULE__,
       where:
-        p.id_in_content_source_platform == ^id_in_content_source_platform and
-          p.content_source_platform == ^content_source_platform
+        p.id_in_content_platform == ^id_in_content_platform and
+          p.content_platform == ^content_platform
     )
   end
 

--- a/lib/glossia_web/controllers/webhooks/github_webhooks_controller.ex
+++ b/lib/glossia_web/controllers/webhooks/github_webhooks_controller.ex
@@ -17,11 +17,11 @@ defmodule GlossiaWeb.Controllers.Webhooks.GitHubWebhooksController do
     payload = conn.assigns.raw_body |> Jason.decode!()
     commit_sha = payload |> get_in(["after"])
     id_in_content_source_platform = payload |> get_in(["repository", "full_name"])
-    content_source = Glossia.ContentSources.content_source(:github)
+    content_source_platform_module = Glossia.ContentSources.get_platform_module(:github)
 
     with {:should_localize, true} <-
            {:should_localize,
-            content_source.should_localize?(id_in_content_source_platform, commit_sha)},
+           content_source_platform_module.should_localize?(id_in_content_source_platform, commit_sha)},
          {:project, %Project{}} <-
            {:project,
             Projects.find_project_by_repository(%{

--- a/lib/glossia_web/controllers/webhooks/github_webhooks_controller.ex
+++ b/lib/glossia_web/controllers/webhooks/github_webhooks_controller.ex
@@ -16,17 +16,17 @@ defmodule GlossiaWeb.Controllers.Webhooks.GitHubWebhooksController do
   defp github_event(conn, "push") do
     payload = conn.assigns.raw_body |> Jason.decode!()
     commit_sha = payload |> get_in(["after"])
-    id_in_content_source_platform = payload |> get_in(["repository", "full_name"])
-    content_source_platform_module = Glossia.ContentSources.get_platform_module(:github)
+    id_in_content_platform = payload |> get_in(["repository", "full_name"])
+    content_platform_module = Glossia.ContentSources.get_platform_module(:github)
 
     with {:should_localize, true} <-
            {:should_localize,
-           content_source_platform_module.should_localize?(id_in_content_source_platform, commit_sha)},
+            content_platform_module.should_localize?(id_in_content_platform, commit_sha)},
          {:project, %Project{}} <-
            {:project,
             Projects.find_project_by_repository(%{
-              id_in_content_source_platform: id_in_content_source_platform,
-              content_source_platform: :github
+              id_in_content_platform: id_in_content_platform,
+              content_platform: :github
             })} do
       FLAME.call(Glossia.EventProcessor, fn ->
         IO.puts("Hello world")

--- a/lib/glossia_web/controllers/webhooks/github_webhooks_controller.ex
+++ b/lib/glossia_web/controllers/webhooks/github_webhooks_controller.ex
@@ -16,15 +16,16 @@ defmodule GlossiaWeb.Controllers.Webhooks.GitHubWebhooksController do
   defp github_event(conn, "push") do
     payload = conn.assigns.raw_body |> Jason.decode!()
     commit_sha = payload |> get_in(["after"])
-    content_source_id = payload |> get_in(["repository", "full_name"])
+    id_in_content_source_platform = payload |> get_in(["repository", "full_name"])
     content_source = Glossia.ContentSources.content_source(:github)
 
     with {:should_localize, true} <-
-           {:should_localize, content_source.should_localize?(content_source_id, commit_sha)},
+           {:should_localize,
+            content_source.should_localize?(id_in_content_source_platform, commit_sha)},
          {:project, %Project{}} <-
            {:project,
             Projects.find_project_by_repository(%{
-              content_source_id: content_source_id,
+              id_in_content_source_platform: id_in_content_source_platform,
               content_source_platform: :github
             })} do
       FLAME.call(Glossia.EventProcessor, fn ->

--- a/lib/glossia_web/live/projects/dashboard.ex
+++ b/lib/glossia_web/live/projects/dashboard.ex
@@ -17,7 +17,7 @@ defmodule GlossiaWeb.LiveViews.Projects.Dashboard do
   def handle_event("localize_most_recent_version", _value, socket) do
     project = GlossiaWeb.LiveViewMountablePlug.url_project(socket)
     content_source = Glossia.ContentSources.content_source(project.content_source_platform)
-    {:ok, version} = content_source.get_most_recent_version(project.content_source_id)
+    {:ok, version} = content_source.get_most_recent_version(project.id_in_content_source_platform)
 
     :ok =
       Glossia.Projects.trigger_build(project, %{

--- a/lib/glossia_web/live/projects/dashboard.ex
+++ b/lib/glossia_web/live/projects/dashboard.ex
@@ -16,8 +16,10 @@ defmodule GlossiaWeb.LiveViews.Projects.Dashboard do
 
   def handle_event("localize_most_recent_version", _value, socket) do
     project = GlossiaWeb.LiveViewMountablePlug.url_project(socket)
-    content_source_platform_module = Glossia.ContentSources.get_platform_module(project.content_source_platform)
-    {:ok, version} = content_source_platform_module.get_most_recent_version(project.id_in_content_source_platform)
+    content_platform_module = Glossia.ContentSources.get_platform_module(project.content_platform)
+
+    {:ok, version} =
+      content_platform_module.get_most_recent_version(project.id_in_content_platform)
 
     :ok =
       Glossia.Projects.trigger_build(project, %{

--- a/lib/glossia_web/live/projects/dashboard.ex
+++ b/lib/glossia_web/live/projects/dashboard.ex
@@ -16,8 +16,8 @@ defmodule GlossiaWeb.LiveViews.Projects.Dashboard do
 
   def handle_event("localize_most_recent_version", _value, socket) do
     project = GlossiaWeb.LiveViewMountablePlug.url_project(socket)
-    content_source = Glossia.ContentSources.content_source(project.content_source_platform)
-    {:ok, version} = content_source.get_most_recent_version(project.id_in_content_source_platform)
+    content_source_platform_module = Glossia.ContentSources.get_platform_module(project.content_source_platform)
+    {:ok, version} = content_source_platform_module.get_most_recent_version(project.id_in_content_source_platform)
 
     :ok =
       Glossia.Projects.trigger_build(project, %{

--- a/lib/glossia_web/live/projects/new.ex
+++ b/lib/glossia_web/live/projects/new.ex
@@ -61,14 +61,14 @@ defmodule GlossiaWeb.LiveViews.Projects.New do
   end
 
   def handle_event("validate", %{"project" => attrs}, socket) do
-    attrs = attrs |> put_account_id_and_content_source_platform_attrs(socket)
+    attrs = attrs |> put_account_id_and_content_platform_attrs(socket)
     changeset = %Project{} |> Project.changeset(attrs) |> Map.put(:action, :insert)
     {:noreply, assign(socket, form: changeset |> to_form())}
   end
 
   def handle_event("save", %{"project" => attrs}, socket) do
     account = socket |> authenticated_user_account
-    attrs = attrs |> put_account_id_and_content_source_platform_attrs(socket)
+    attrs = attrs |> put_account_id_and_content_platform_attrs(socket)
 
     case Glossia.Projects.create_project(attrs) do
       {:ok, project} ->
@@ -79,11 +79,11 @@ defmodule GlossiaWeb.LiveViews.Projects.New do
     end
   end
 
-  defp put_account_id_and_content_source_platform_attrs(attrs, socket) do
+  defp put_account_id_and_content_platform_attrs(attrs, socket) do
     account = socket |> authenticated_user_account
 
     attrs
-    |> Map.merge(%{account_id: account.id, content_source_platform: :github})
+    |> Map.merge(%{account_id: account.id, content_platform: :github})
     |> Useful.atomize_map_keys()
   end
 

--- a/lib/glossia_web/live/projects/new.html.heex
+++ b/lib/glossia_web/live/projects/new.html.heex
@@ -59,7 +59,7 @@
               Select a GitHub repository
             </label>
             <.input
-              field={@form[:id_in_content_source_platform]}
+              field={@form[:id_in_content_platform]}
               type="select"
               options={@repositories}
               class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"

--- a/lib/glossia_web/live/projects/new.html.heex
+++ b/lib/glossia_web/live/projects/new.html.heex
@@ -59,7 +59,7 @@
               Select a GitHub repository
             </label>
             <.input
-              field={@form[:content_source_id]}
+              field={@form[:id_in_content_source_platform]}
               type="select"
               options={@repositories}
               class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"

--- a/lib/glossia_web/live/projects/versions.ex
+++ b/lib/glossia_web/live/projects/versions.ex
@@ -9,7 +9,7 @@ defmodule GlossiaWeb.LiveViews.Projects.Versions do
   def get_versions(socket) do
     project = GlossiaWeb.LiveViewMountablePlug.url_project(socket)
     content_source = Glossia.ContentSources.content_source(project.content_source_platform)
-    versions = content_source.get_versions(project.content_source_id)
+    versions = content_source.get_versions(project.id_in_content_source_platform)
     versions
   end
 end

--- a/lib/glossia_web/live/projects/versions.ex
+++ b/lib/glossia_web/live/projects/versions.ex
@@ -8,8 +8,8 @@ defmodule GlossiaWeb.LiveViews.Projects.Versions do
 
   def get_versions(socket) do
     project = GlossiaWeb.LiveViewMountablePlug.url_project(socket)
-    content_source_platform_module = Glossia.ContentSources.get_platform_module(project.content_source_platform)
-    versions = content_source_platform_module.get_versions(project.id_in_content_source_platform)
+    content_platform_module = Glossia.ContentSources.get_platform_module(project.content_platform)
+    versions = content_platform_module.get_versions(project.id_in_content_platform)
     versions
   end
 end

--- a/lib/glossia_web/live/projects/versions.ex
+++ b/lib/glossia_web/live/projects/versions.ex
@@ -8,8 +8,8 @@ defmodule GlossiaWeb.LiveViews.Projects.Versions do
 
   def get_versions(socket) do
     project = GlossiaWeb.LiveViewMountablePlug.url_project(socket)
-    content_source = Glossia.ContentSources.content_source(project.content_source_platform)
-    versions = content_source.get_versions(project.id_in_content_source_platform)
+    content_source_platform_module = Glossia.ContentSources.get_platform_module(project.content_source_platform)
+    versions = content_source_platform_module.get_versions(project.id_in_content_source_platform)
     versions
   end
 end

--- a/lib/glossia_web/plugs/validate_github_webhook_plug.ex
+++ b/lib/glossia_web/plugs/validate_github_webhook_plug.ex
@@ -16,9 +16,9 @@ defmodule GlossiaWeb.Plugs.ValidateGitHubWebhookPlug do
   @spec call(Conn.t(), term()) :: Conn.t()
   def call(%Conn{method: method, request_path: "/webhooks/github"} = conn, _opts)
       when method == "POST" or method == "PUT" do
-    github_content_source = Glossia.ContentSources.content_source(:github)
+    github_content_source_platform_module = Glossia.ContentSources.get_platform_module(:github)
 
-    case github_content_source.is_webhook_payload_valid?(
+    case github_content_source_platform_module.is_webhook_payload_valid?(
            conn.req_headers,
            conn.assigns.raw_body
          ) do

--- a/lib/glossia_web/plugs/validate_github_webhook_plug.ex
+++ b/lib/glossia_web/plugs/validate_github_webhook_plug.ex
@@ -16,9 +16,9 @@ defmodule GlossiaWeb.Plugs.ValidateGitHubWebhookPlug do
   @spec call(Conn.t(), term()) :: Conn.t()
   def call(%Conn{method: method, request_path: "/webhooks/github"} = conn, _opts)
       when method == "POST" or method == "PUT" do
-    github_content_source_platform_module = Glossia.ContentSources.get_platform_module(:github)
+    github_content_platform_module = Glossia.ContentSources.get_platform_module(:github)
 
-    case github_content_source_platform_module.is_webhook_payload_valid?(
+    case github_content_platform_module.is_webhook_payload_valid?(
            conn.req_headers,
            conn.assigns.raw_body
          ) do

--- a/mix.exs
+++ b/mix.exs
@@ -111,6 +111,7 @@ defmodule Glossia.MixProject do
         "ecto.migrate",
         "run priv/repo/seeds.exs"
       ],
+      "ecto.migrate": ["ecto.migrate", "ecto.dump"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
       "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],

--- a/priv/repo/migrations/20240213055018_rename_content_source_id_to_content_id.exs
+++ b/priv/repo/migrations/20240213055018_rename_content_source_id_to_content_id.exs
@@ -5,7 +5,8 @@ defmodule Glossia.Repo.Migrations.RenameContentSourceIdToContentId do
     drop unique_index(:projects, [:content_source_id, :content_source_platform])
     drop unique_index(:builds, [:version, :type, :content_source_id, :content_source_platform])
 
-    rename table(:projects), :content_source_id, to: :id_in_content_source_platform
+    rename table(:projects), :content_source_id, to: :id_in_content_platform
+    rename table(:projects), :content_source_platform, to: :content_platform
 
     alter table(:builds) do
       remove :content_source_id
@@ -13,6 +14,6 @@ defmodule Glossia.Repo.Migrations.RenameContentSourceIdToContentId do
     end
 
     create unique_index(:builds, [:version, :type])
-    create unique_index(:projects, [:id_in_content_source_platform, :content_source_platform])
+    create unique_index(:projects, [:id_in_content_platform, :content_platform])
   end
 end

--- a/priv/repo/migrations/20240213055018_rename_content_source_id_to_content_id.exs
+++ b/priv/repo/migrations/20240213055018_rename_content_source_id_to_content_id.exs
@@ -1,0 +1,18 @@
+defmodule Glossia.Repo.Migrations.RenameContentSourceIdToContentId do
+  use Ecto.Migration
+
+  def change do
+    drop unique_index(:projects, [:content_source_id, :content_source_platform])
+    drop unique_index(:builds, [:version, :type, :content_source_id, :content_source_platform])
+
+    rename table(:projects), :content_source_id, to: :id_in_content_source_platform
+
+    alter table(:builds) do
+      remove :content_source_id
+      remove :content_source_platform
+    end
+
+    create unique_index(:builds, [:version, :type])
+    create unique_index(:projects, [:id_in_content_source_platform, :content_source_platform])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -19,16 +19,16 @@ organization = organization |> Repo.preload(:account)
 
 project =
   Repo.get_by(Project,
-    id_in_content_source_platform: "glossia/modulex",
-    content_source_platform: :github
+    id_in_content_platform: "glossia/modulex",
+    content_platform: :github
   )
   |> case do
     nil ->
       {:ok, project} =
         Projects.create_project(%{
           handle: "glossia",
-          id_in_content_source_platform: "glossia/glossia",
-          content_source_platform: :github,
+          id_in_content_platform: "glossia/glossia",
+          content_platform: :github,
           account_id: organization.account.id
         })
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -18,13 +18,16 @@ organization =
 organization = organization |> Repo.preload(:account)
 
 project =
-  Repo.get_by(Project, content_source_id: "glossia/modulex", content_source_platform: :github)
+  Repo.get_by(Project,
+    id_in_content_source_platform: "glossia/modulex",
+    content_source_platform: :github
+  )
   |> case do
     nil ->
       {:ok, project} =
         Projects.create_project(%{
           handle: "glossia",
-          content_source_id: "glossia/glossia",
+          id_in_content_source_platform: "glossia/glossia",
           content_source_platform: :github,
           account_id: organization.account.id
         })

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -1,0 +1,598 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 15.5
+-- Dumped by pg_dump version 15.5
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: citext; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION citext; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION citext IS 'data type for case-insensitive character strings';
+
+
+--
+-- Name: oban_job_state; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.oban_job_state AS ENUM (
+    'available',
+    'scheduled',
+    'executing',
+    'retryable',
+    'completed',
+    'discarded',
+    'cancelled'
+);
+
+
+--
+-- Name: oban_jobs_notify(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.oban_jobs_notify() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  channel text;
+  notice json;
+BEGIN
+  IF NEW.state = 'available' THEN
+    channel = 'public.oban_insert';
+    notice = json_build_object('queue', NEW.queue);
+
+    PERFORM pg_notify(channel, notice::text);
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.accounts (
+    id uuid NOT NULL,
+    handle public.citext NOT NULL,
+    inserted_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL,
+    customer_id character varying(255)
+);
+
+
+--
+-- Name: builds; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.builds (
+    id uuid NOT NULL,
+    version character varying(255) NOT NULL,
+    type integer NOT NULL,
+    project_id uuid NOT NULL,
+    status integer DEFAULT 1 NOT NULL,
+    vm_id character varying(255),
+    inserted_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL,
+    vm_logs_url character varying(255),
+    markdown_error_message character varying(255),
+    metadata jsonb DEFAULT '{}'::jsonb
+);
+
+
+--
+-- Name: credentials; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.credentials (
+    id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    provider integer NOT NULL,
+    provider_id integer NOT NULL,
+    token character varying(255) NOT NULL,
+    refresh_token character varying(255) NOT NULL,
+    expires_at timestamp(0) without time zone NOT NULL,
+    inserted_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL,
+    refresh_token_expires_at timestamp(0) without time zone
+);
+
+
+--
+-- Name: oban_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oban_jobs (
+    id bigint NOT NULL,
+    state public.oban_job_state DEFAULT 'available'::public.oban_job_state NOT NULL,
+    queue text DEFAULT 'default'::text NOT NULL,
+    worker text NOT NULL,
+    args jsonb DEFAULT '{}'::jsonb NOT NULL,
+    errors jsonb[] DEFAULT ARRAY[]::jsonb[] NOT NULL,
+    attempt integer DEFAULT 0 NOT NULL,
+    max_attempts integer DEFAULT 20 NOT NULL,
+    inserted_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
+    scheduled_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
+    attempted_at timestamp without time zone,
+    completed_at timestamp without time zone,
+    attempted_by text[],
+    discarded_at timestamp without time zone,
+    priority integer DEFAULT 0 NOT NULL,
+    tags character varying(255)[] DEFAULT ARRAY[]::character varying[],
+    meta jsonb DEFAULT '{}'::jsonb,
+    cancelled_at timestamp without time zone,
+    CONSTRAINT attempt_range CHECK (((attempt >= 0) AND (attempt <= max_attempts))),
+    CONSTRAINT positive_max_attempts CHECK ((max_attempts > 0)),
+    CONSTRAINT priority_range CHECK (((priority >= 0) AND (priority <= 3))),
+    CONSTRAINT queue_length CHECK (((char_length(queue) > 0) AND (char_length(queue) < 128))),
+    CONSTRAINT worker_length CHECK (((char_length(worker) > 0) AND (char_length(worker) < 128)))
+);
+
+
+--
+-- Name: TABLE oban_jobs; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.oban_jobs IS '11';
+
+
+--
+-- Name: oban_jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.oban_jobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: oban_jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.oban_jobs_id_seq OWNED BY public.oban_jobs.id;
+
+
+--
+-- Name: oban_peers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE UNLOGGED TABLE public.oban_peers (
+    name text NOT NULL,
+    node text NOT NULL,
+    started_at timestamp without time zone NOT NULL,
+    expires_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: organization_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_users (
+    id uuid NOT NULL,
+    role integer NOT NULL,
+    organization_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    inserted_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL
+);
+
+
+--
+-- Name: organizations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organizations (
+    id uuid NOT NULL,
+    account_id uuid NOT NULL,
+    inserted_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL
+);
+
+
+--
+-- Name: projects; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.projects (
+    id uuid NOT NULL,
+    handle public.citext NOT NULL,
+    account_id uuid NOT NULL,
+    id_in_content_source_platform public.citext NOT NULL,
+    content_source_platform integer NOT NULL,
+    inserted_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL,
+    visibility integer DEFAULT 1 NOT NULL
+);
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version bigint NOT NULL,
+    inserted_at timestamp(0) without time zone
+);
+
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users (
+    id uuid NOT NULL,
+    email public.citext NOT NULL,
+    hashed_password character varying(255) NOT NULL,
+    confirmed_at timestamp(0) without time zone,
+    inserted_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL,
+    account_id uuid NOT NULL,
+    last_visited_project_id uuid,
+    role integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: users_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users_tokens (
+    id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    token bytea NOT NULL,
+    context character varying(255) NOT NULL,
+    sent_to character varying(255),
+    inserted_at timestamp(0) without time zone NOT NULL
+);
+
+
+--
+-- Name: oban_jobs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oban_jobs ALTER COLUMN id SET DEFAULT nextval('public.oban_jobs_id_seq'::regclass);
+
+
+--
+-- Name: accounts accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.accounts
+    ADD CONSTRAINT accounts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: credentials credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.credentials
+    ADD CONSTRAINT credentials_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: builds git_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.builds
+    ADD CONSTRAINT git_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oban_jobs oban_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oban_jobs
+    ADD CONSTRAINT oban_jobs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oban_peers oban_peers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oban_peers
+    ADD CONSTRAINT oban_peers_pkey PRIMARY KEY (name);
+
+
+--
+-- Name: organization_users organization_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_users
+    ADD CONSTRAINT organization_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: organizations organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organizations
+    ADD CONSTRAINT organizations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.projects
+    ADD CONSTRAINT projects_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: users_tokens users_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users_tokens
+    ADD CONSTRAINT users_tokens_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: accounts_customer_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX accounts_customer_id_index ON public.accounts USING btree (customer_id);
+
+
+--
+-- Name: accounts_handle_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX accounts_handle_index ON public.accounts USING btree (handle);
+
+
+--
+-- Name: builds_version_type_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX builds_version_type_index ON public.builds USING btree (version, type);
+
+
+--
+-- Name: credentials_user_id_provider_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX credentials_user_id_provider_index ON public.credentials USING btree (user_id, provider);
+
+
+--
+-- Name: oban_jobs_args_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX oban_jobs_args_index ON public.oban_jobs USING gin (args);
+
+
+--
+-- Name: oban_jobs_meta_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX oban_jobs_meta_index ON public.oban_jobs USING gin (meta);
+
+
+--
+-- Name: oban_jobs_state_queue_priority_scheduled_at_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX oban_jobs_state_queue_priority_scheduled_at_id_index ON public.oban_jobs USING btree (state, queue, priority, scheduled_at, id);
+
+
+--
+-- Name: organization_users_organization_id_user_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_users_organization_id_user_id_index ON public.organization_users USING btree (organization_id, user_id);
+
+
+--
+-- Name: organizations_account_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organizations_account_id_index ON public.organizations USING btree (account_id);
+
+
+--
+-- Name: projects_handle_account_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX projects_handle_account_id_index ON public.projects USING btree (account_id, handle);
+
+
+--
+-- Name: projects_id_in_content_source_platform_content_source_platform_; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX projects_id_in_content_source_platform_content_source_platform_ ON public.projects USING btree (id_in_content_source_platform, content_source_platform);
+
+
+--
+-- Name: users_account_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX users_account_id_index ON public.users USING btree (account_id);
+
+
+--
+-- Name: users_email_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX users_email_index ON public.users USING btree (email);
+
+
+--
+-- Name: users_tokens_context_token_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX users_tokens_context_token_index ON public.users_tokens USING btree (context, token);
+
+
+--
+-- Name: users_tokens_user_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX users_tokens_user_id_index ON public.users_tokens USING btree (user_id);
+
+
+--
+-- Name: oban_jobs oban_notify; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER oban_notify AFTER INSERT ON public.oban_jobs FOR EACH ROW EXECUTE FUNCTION public.oban_jobs_notify();
+
+
+--
+-- Name: credentials credentials_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.credentials
+    ADD CONSTRAINT credentials_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: builds git_events_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.builds
+    ADD CONSTRAINT git_events_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: organization_users organization_users_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_users
+    ADD CONSTRAINT organization_users_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: organization_users organization_users_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_users
+    ADD CONSTRAINT organization_users_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: organizations organizations_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organizations
+    ADD CONSTRAINT organizations_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id);
+
+
+--
+-- Name: projects projects_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.projects
+    ADD CONSTRAINT projects_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id);
+
+
+--
+-- Name: users users_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id);
+
+
+--
+-- Name: users users_last_visited_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_last_visited_project_id_fkey FOREIGN KEY (last_visited_project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: users_tokens users_tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users_tokens
+    ADD CONSTRAINT users_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+INSERT INTO public."schema_migrations" (version) VALUES (20230711104335);
+INSERT INTO public."schema_migrations" (version) VALUES (20230711104631);
+INSERT INTO public."schema_migrations" (version) VALUES (20230711152254);
+INSERT INTO public."schema_migrations" (version) VALUES (20230717082832);
+INSERT INTO public."schema_migrations" (version) VALUES (20230718121759);
+INSERT INTO public."schema_migrations" (version) VALUES (20230718181410);
+INSERT INTO public."schema_migrations" (version) VALUES (20230720134037);
+INSERT INTO public."schema_migrations" (version) VALUES (20230720172921);
+INSERT INTO public."schema_migrations" (version) VALUES (20230724101641);
+INSERT INTO public."schema_migrations" (version) VALUES (20230724161306);
+INSERT INTO public."schema_migrations" (version) VALUES (20230725141331);
+INSERT INTO public."schema_migrations" (version) VALUES (20230725150014);
+INSERT INTO public."schema_migrations" (version) VALUES (20230726161449);
+INSERT INTO public."schema_migrations" (version) VALUES (20230726161505);
+INSERT INTO public."schema_migrations" (version) VALUES (20230726182257);
+INSERT INTO public."schema_migrations" (version) VALUES (20230727131541);
+INSERT INTO public."schema_migrations" (version) VALUES (20230727132456);
+INSERT INTO public."schema_migrations" (version) VALUES (20230727132757);
+INSERT INTO public."schema_migrations" (version) VALUES (20230727134150);
+INSERT INTO public."schema_migrations" (version) VALUES (20230727135033);
+INSERT INTO public."schema_migrations" (version) VALUES (20230727142222);
+INSERT INTO public."schema_migrations" (version) VALUES (20230727143003);
+INSERT INTO public."schema_migrations" (version) VALUES (20230730165042);
+INSERT INTO public."schema_migrations" (version) VALUES (20230730171003);
+INSERT INTO public."schema_migrations" (version) VALUES (20230730194205);
+INSERT INTO public."schema_migrations" (version) VALUES (20230814161822);
+INSERT INTO public."schema_migrations" (version) VALUES (20230814170535);
+INSERT INTO public."schema_migrations" (version) VALUES (20230829093317);
+INSERT INTO public."schema_migrations" (version) VALUES (20230901124423);
+INSERT INTO public."schema_migrations" (version) VALUES (20230902105218);
+INSERT INTO public."schema_migrations" (version) VALUES (20230911154758);
+INSERT INTO public."schema_migrations" (version) VALUES (20230914144628);
+INSERT INTO public."schema_migrations" (version) VALUES (20230923162017);
+INSERT INTO public."schema_migrations" (version) VALUES (20230923172220);
+INSERT INTO public."schema_migrations" (version) VALUES (20230924145856);
+INSERT INTO public."schema_migrations" (version) VALUES (20230924154601);
+INSERT INTO public."schema_migrations" (version) VALUES (20231006134415);
+INSERT INTO public."schema_migrations" (version) VALUES (20231031133721);
+INSERT INTO public."schema_migrations" (version) VALUES (20240213055018);

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -225,8 +225,8 @@ CREATE TABLE public.projects (
     id uuid NOT NULL,
     handle public.citext NOT NULL,
     account_id uuid NOT NULL,
-    id_in_content_source_platform public.citext NOT NULL,
-    content_source_platform integer NOT NULL,
+    id_in_content_platform public.citext NOT NULL,
+    content_platform integer NOT NULL,
     inserted_at timestamp(0) without time zone NOT NULL,
     updated_at timestamp(0) without time zone NOT NULL,
     visibility integer DEFAULT 1 NOT NULL
@@ -440,10 +440,10 @@ CREATE UNIQUE INDEX projects_handle_account_id_index ON public.projects USING bt
 
 
 --
--- Name: projects_id_in_content_source_platform_content_source_platform_; Type: INDEX; Schema: public; Owner: -
+-- Name: projects_id_in_content_platform_content_platform_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX projects_id_in_content_source_platform_content_source_platform_ ON public.projects USING btree (id_in_content_source_platform, content_source_platform);
+CREATE UNIQUE INDEX projects_id_in_content_platform_content_platform_index ON public.projects USING btree (id_in_content_platform, content_platform);
 
 
 --

--- a/priv/static/builder/utils/environment.ts
+++ b/priv/static/builder/utils/environment.ts
@@ -73,7 +73,7 @@ export function getAccessToken(env: Deno.Env = Deno.env) {
  * @returns
  */
 export function getIDInContentSourcePlatform(env: Deno.Env = Deno.env) {
-  return env.get("GLOSSIA_ID_IN_CONTENT_SOURCE_PLATFORM");
+  return env.get("GLOSSIA_id_in_content_platform");
 }
 
 type ContentSourcePlatform = "github";
@@ -86,7 +86,7 @@ type ContentSourcePlatform = "github";
 export function getContentSourcePlatform(
   env: Deno.Env = Deno.env,
 ): ContentSourcePlatform | undefined {
-  const platform = env.get("GLOSSIA_CONTENT_SOURCE_PLATFORM");
+  const platform = env.get("GLOSSIA_content_platform");
   if (!platform) return undefined;
   switch (platform) {
     case "github":

--- a/priv/static/builder/utils/environment.ts
+++ b/priv/static/builder/utils/environment.ts
@@ -72,11 +72,11 @@ export function getAccessToken(env: Deno.Env = Deno.env) {
  * @param env {Deno.Env} An object containing the enviornment variables of the system.
  * @returns
  */
-export function getContentSourceId(env: Deno.Env = Deno.env) {
-  return env.get("GLOSSIA_CONTENT_SOURCE_ID");
+export function getIDInContentSourcePlatform(env: Deno.Env = Deno.env) {
+  return env.get("GLOSSIA_ID_IN_CONTENT_SOURCE_PLATFORM");
 }
 
-type VCSPlatform = "github";
+type ContentSourcePlatform = "github";
 
 /**
  * It returns the identifier of the VCS platform (e.g. github)
@@ -85,7 +85,7 @@ type VCSPlatform = "github";
  */
 export function getContentSourcePlatform(
   env: Deno.Env = Deno.env,
-): VCSPlatform | undefined {
+): ContentSourcePlatform | undefined {
   const platform = env.get("GLOSSIA_CONTENT_SOURCE_PLATFORM");
   if (!platform) return undefined;
   switch (platform) {

--- a/priv/static/builder/utils/environment_test.ts
+++ b/priv/static/builder/utils/environment_test.ts
@@ -10,6 +10,6 @@ Deno.test("getBuildType throws an error when the event is unsupported", () => {
 
 Deno.test("getContentSourcePlatform throws an error when the VCS platform is unsupported", () => {
   assertThrows(() => {
-    getBuildType(getMockedEnv({ GLOSSIA_CONTENT_SOURCE_PLATFORM: "invalid" }));
+    getBuildType(getMockedEnv({ GLOSSIA_content_platform: "invalid" }));
   }, "This instance of the builder doesn't support the VCS platform 'invalid'");
 });

--- a/priv/static/builder/utils/git.ts
+++ b/priv/static/builder/utils/git.ts
@@ -1,8 +1,8 @@
 import {
   getBuildVersion,
   getContentSourceAccessToken,
-  getContentSourceId,
   getContentSourcePlatform,
+  getIDInContentSourcePlatform,
 } from "./environment.ts";
 
 // https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
@@ -13,23 +13,29 @@ export async function cloneGitRepository(
     root: root,
     gitCommitSHA: getBuildVersion()!,
     gitAccessToken: getContentSourceAccessToken()!,
-    vcsPlatform: getContentSourcePlatform()!,
-    vcsId: getContentSourceId()!,
+    contentSourcePlatform: getContentSourcePlatform()!,
+    idInContentSourcePlatform: getIDInContentSourcePlatform()!,
   });
 }
 
 export async function clone(
-  { root, gitAccessToken, vcsPlatform, vcsId, gitCommitSHA }: {
+  {
+    root,
+    gitAccessToken,
+    contentSourcePlatform,
+    idInContentSourcePlatform,
+    gitCommitSHA,
+  }: {
     root: string;
     gitCommitSHA: string | undefined;
     gitAccessToken: string | undefined;
-    vcsPlatform: string;
-    vcsId: string;
+    contentSourcePlatform: string;
+    idInContentSourcePlatform: string;
   },
 ) {
   const remoteURL = gitAccessToken
-    ? `https://x-access-token:${gitAccessToken}@${vcsPlatform}.com/${vcsId}.git`
-    : `https://${vcsPlatform}.com/${vcsId}.git`;
+    ? `https://x-access-token:${gitAccessToken}@${contentSourcePlatform}.com/${idInContentSourcePlatform}.git`
+    : `https://${contentSourcePlatform}.com/${idInContentSourcePlatform}.git`;
   console.log(`Cloning ${remoteURL}`);
   const cloneArgs = ["git", "clone", remoteURL, root, "--filter=tree:0"];
   console.log("Running:", cloneArgs.join(" "));

--- a/priv/static/builder/utils/git_test.ts
+++ b/priv/static/builder/utils/git_test.ts
@@ -7,8 +7,8 @@ Deno.test("clone clones the repository", async () => {
     // When
     await clone({
       root: tmpDir,
-      vcsPlatform: "github",
-      vcsId: "glossia/glossia",
+      contentSourcePlatform: "github",
+      idInContentSourcePlatform: "glossia/glossia",
       gitCommitSHA: undefined,
       gitAccessToken: getContentSourceAccessToken(),
     });

--- a/test/glossia/builds/build_test.exs
+++ b/test/glossia/builds/build_test.exs
@@ -16,36 +16,10 @@ defmodule Glossia.Builds.BuildTest do
       assert %{version: ["can't be blank"]} = errors
     end
 
-    test "validates the presence of repository_id" do
-      # Given
-      attrs = %{version: "1234567890"}
-
-      # When
-      changeset = Build.changeset(%Build{}, attrs)
-
-      # Then
-      errors = errors_on(changeset)
-      assert %{content_source_id: ["can't be blank"]} = errors
-    end
-
-    test "validates the presence of vcs" do
-      # Given
-      attrs = %{version: "1234567890", content_source_id: "1234567890"}
-
-      # When
-      changeset = Build.changeset(%Build{}, attrs)
-
-      # Then
-      errors = errors_on(changeset)
-      assert %{content_source_platform: ["can't be blank"]} = errors
-    end
-
     test "validates the presence of project_id" do
       # Given
       attrs = %{
-        version: "1234567890",
-        content_source_id: "1234567890",
-        content_source_platform: :github
+        version: "1234567890"
       }
 
       # When
@@ -54,46 +28,6 @@ defmodule Glossia.Builds.BuildTest do
       # Then
       errors = errors_on(changeset)
       assert %{project_id: ["can't be blank"]} = errors
-    end
-
-    test "validate the inclusion of vcs" do
-      # Given
-      attrs = %{
-        version: "1234567890",
-        content_source_id: "1234567890",
-        content_source_platform: :gitlab,
-        project_id: 1,
-        type: :push
-      }
-
-      # When
-      changeset = Build.changeset(%Build{}, attrs)
-
-      # Then
-      errors = errors_on(changeset)
-      assert %{content_source_platform: ["is invalid"]} = errors
-    end
-
-    test "validate the uniqueness of version, repository_id and vcs" do
-      # Given
-      project = Glossia.ProjectsFixtures.project_fixture()
-
-      attrs = %{
-        type: :new_version,
-        version: "1234567890",
-        content_source_id: "1234567890",
-        content_source_platform: :github,
-        project_id: project.id
-      }
-
-      %Build{} |> Build.changeset(attrs) |> Repo.insert!()
-
-      # When
-      {:error, changeset} = %Build{} |> Build.changeset(attrs) |> Repo.insert()
-
-      # Then
-      errors = errors_on(changeset)
-      assert %{version: ["has already been taken"]} = errors
     end
   end
 end

--- a/test/glossia/content_sources/github_test.exs
+++ b/test/glossia/content_sources/github_test.exs
@@ -1,6 +1,6 @@
-defmodule Glossia.ContentSources.GitHubTest do
+defmodule Glossia.ContentSources.Platforms.GitHubTest do
   use ExUnit.Case, async: true
-  import Glossia.ContentSources.GitHub
+  import Glossia.ContentSources.Platforms.GitHub
   use ExVCR.Mock, adapter: ExVCR.Adapter.Finch
 
   test "supports_versioning? returns true" do
@@ -16,7 +16,7 @@ defmodule Glossia.ContentSources.GitHubTest do
     response =
       use_cassette "glossia/content_sources/github_test/get_most_recent_version",
         match_requests_on: [:request_body] do
-        Glossia.ContentSources.GitHub.get_most_recent_version("glossia/glossia")
+        Glossia.ContentSources.Platforms.GitHub.get_most_recent_version("glossia/glossia")
       end
 
     # Then
@@ -28,7 +28,7 @@ defmodule Glossia.ContentSources.GitHubTest do
     response =
       use_cassette "glossia/content_sources/github_test/get_versions",
         match_requests_on: [:request_body] do
-        Glossia.ContentSources.GitHub.get_versions("glossia/glossia")
+        Glossia.ContentSources.Platforms.GitHub.get_versions("glossia/glossia")
       end
 
     # Then
@@ -40,7 +40,7 @@ defmodule Glossia.ContentSources.GitHubTest do
     response =
       use_cassette "glossia/content_sources/github_test/get_default_branch",
         match_requests_on: [:request_body] do
-        Glossia.ContentSources.GitHub.get_default_branch("glossia/glossia")
+        Glossia.ContentSources.Platforms.GitHub.get_default_branch("glossia/glossia")
       end
 
     # Then

--- a/test/glossia/projects/models/project_test.exs
+++ b/test/glossia/projects/models/project_test.exs
@@ -9,7 +9,7 @@ defmodule Glossia.Projects.ProjectTest do
       project = %Project{}
 
       attrs = %{
-        content_source_id: "glossia/glossia",
+        id_in_content_source_platform: "glossia/glossia",
         content_source_platform: :github,
         account_id: 1
       }
@@ -32,13 +32,18 @@ defmodule Glossia.Projects.ProjectTest do
 
       # Then
       errors = errors_on(changeset)
-      assert %{content_source_id: ["This attribute is required"]} = errors
+      assert %{id_in_content_source_platform: ["This attribute is required"]} = errors
     end
 
     test "validates that vcs is required" do
       # Given
       project = %Project{}
-      attrs = %{handle: "glossia", content_source_id: "glossia/glossia", account_id: 1}
+
+      attrs = %{
+        handle: "glossia",
+        id_in_content_source_platform: "glossia/glossia",
+        account_id: 1
+      }
 
       # When
       changeset = Project.changeset(project, attrs)
@@ -54,7 +59,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "glossia",
-        content_source_id: "glossia/glossia",
+        id_in_content_source_platform: "glossia/glossia",
         content_source_platform: :github
       }
 
@@ -72,7 +77,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "glossia",
-        content_source_id: "glossia/glossia",
+        id_in_content_source_platform: "glossia/glossia",
         content_source_platform: :invalid_vcs,
         account_id: 1
       }
@@ -91,7 +96,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "invalid handle",
-        content_source_id: "glossia/glossia",
+        id_in_content_source_platform: "glossia/glossia",
         content_source_platform: :github,
         account_id: 1
       }
@@ -110,7 +115,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "a",
-        content_source_id: "glossia/glossia",
+        id_in_content_source_platform: "glossia/glossia",
         content_source_platform: :github,
         account_id: 1
       }
@@ -129,7 +134,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "aasdgasgasgdasdgasdgasgasdgasgsags",
-        content_source_id: "glossia/glossia",
+        id_in_content_source_platform: "glossia/glossia",
         content_source_platform: :github,
         account_id: 1
       }

--- a/test/glossia/projects/models/project_test.exs
+++ b/test/glossia/projects/models/project_test.exs
@@ -9,8 +9,8 @@ defmodule Glossia.Projects.ProjectTest do
       project = %Project{}
 
       attrs = %{
-        id_in_content_source_platform: "glossia/glossia",
-        content_source_platform: :github,
+        id_in_content_platform: "glossia/glossia",
+        content_platform: :github,
         account_id: 1
       }
 
@@ -25,14 +25,14 @@ defmodule Glossia.Projects.ProjectTest do
     test "validates that repository_id is required" do
       # Given
       project = %Project{}
-      attrs = %{handle: "glossia", content_source_platform: :github, account_id: 1}
+      attrs = %{handle: "glossia", content_platform: :github, account_id: 1}
 
       # When
       changeset = Project.changeset(project, attrs)
 
       # Then
       errors = errors_on(changeset)
-      assert %{id_in_content_source_platform: ["This attribute is required"]} = errors
+      assert %{id_in_content_platform: ["This attribute is required"]} = errors
     end
 
     test "validates that vcs is required" do
@@ -41,7 +41,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "glossia",
-        id_in_content_source_platform: "glossia/glossia",
+        id_in_content_platform: "glossia/glossia",
         account_id: 1
       }
 
@@ -50,7 +50,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       # Then
       errors = errors_on(changeset)
-      assert %{content_source_platform: ["This attribute is required"]} = errors
+      assert %{content_platform: ["This attribute is required"]} = errors
     end
 
     test "validates that account_id is required" do
@@ -59,8 +59,8 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "glossia",
-        id_in_content_source_platform: "glossia/glossia",
-        content_source_platform: :github
+        id_in_content_platform: "glossia/glossia",
+        content_platform: :github
       }
 
       # When
@@ -77,8 +77,8 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "glossia",
-        id_in_content_source_platform: "glossia/glossia",
-        content_source_platform: :invalid_vcs,
+        id_in_content_platform: "glossia/glossia",
+        content_platform: :invalid_vcs,
         account_id: 1
       }
 
@@ -87,7 +87,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       # Then
       errors = errors_on(changeset)
-      assert %{content_source_platform: ["is invalid"]} = errors
+      assert %{content_platform: ["is invalid"]} = errors
     end
 
     test "validates that handle is alphanumeric" do
@@ -96,8 +96,8 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "invalid handle",
-        id_in_content_source_platform: "glossia/glossia",
-        content_source_platform: :github,
+        id_in_content_platform: "glossia/glossia",
+        content_platform: :github,
         account_id: 1
       }
 
@@ -115,8 +115,8 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "a",
-        id_in_content_source_platform: "glossia/glossia",
-        content_source_platform: :github,
+        id_in_content_platform: "glossia/glossia",
+        content_platform: :github,
         account_id: 1
       }
 
@@ -134,8 +134,8 @@ defmodule Glossia.Projects.ProjectTest do
 
       attrs = %{
         handle: "aasdgasgasgdasdgasdgasgasdgasgsags",
-        id_in_content_source_platform: "glossia/glossia",
-        content_source_platform: :github,
+        id_in_content_platform: "glossia/glossia",
+        content_platform: :github,
         account_id: 1
       }
 
@@ -147,12 +147,12 @@ defmodule Glossia.Projects.ProjectTest do
       assert %{handle: ["The length should be between 3 and 20 characters"]} = errors
     end
 
-    test "validates the inclusion of content_source_platform in the supported types" do
+    test "validates the inclusion of content_platform in the supported types" do
       # Given
       project = %Project{}
 
       attrs = %{
-        content_source_platform: :invalid
+        content_platform: :invalid
       }
 
       # When
@@ -160,7 +160,7 @@ defmodule Glossia.Projects.ProjectTest do
 
       # Then
       errors = errors_on(changeset)
-      assert %{content_source_platform: ["is invalid"]} = errors
+      assert %{content_platform: ["is invalid"]} = errors
     end
   end
 end

--- a/test/glossia/projects_test.exs
+++ b/test/glossia/projects_test.exs
@@ -12,14 +12,14 @@ defmodule Glossia.ProjectsTest do
       # When
       got =
         Projects.find_project_by_repository(%{
-          content_source_id: project.content_source_id,
+          id_in_content_source_platform: project.id_in_content_source_platform,
           content_source_platform: project.content_source_platform
         })
 
       # Then
       assert got.id == project.id
       assert got.handle == project.handle
-      assert got.content_source_id == project.content_source_id
+      assert got.id_in_content_source_platform == project.id_in_content_source_platform
     end
   end
 

--- a/test/glossia/projects_test.exs
+++ b/test/glossia/projects_test.exs
@@ -12,14 +12,14 @@ defmodule Glossia.ProjectsTest do
       # When
       got =
         Projects.find_project_by_repository(%{
-          id_in_content_source_platform: project.id_in_content_source_platform,
-          content_source_platform: project.content_source_platform
+          id_in_content_platform: project.id_in_content_platform,
+          content_platform: project.content_platform
         })
 
       # Then
       assert got.id == project.id
       assert got.handle == project.handle
-      assert got.id_in_content_source_platform == project.id_in_content_source_platform
+      assert got.id_in_content_platform == project.id_in_content_platform
     end
   end
 

--- a/test/glossia_web/plugs/validate_github_webhook_plug_test.exs
+++ b/test/glossia_web/plugs/validate_github_webhook_plug_test.exs
@@ -29,7 +29,7 @@ defmodule GlossiaWeb.Plugs.ValidateGitHubWebhookPlugTest do
     # Given
     opts = ValidateGitHubWebhookPlug.init([])
     payload = "payload"
-    secret = Glossia.ContentSources.GitHub.webhook_secret()
+    secret = Glossia.ContentSources.Platforms.GitHub.webhook_secret()
     signature = :crypto.mac(:hmac, :sha, secret, payload) |> Base.encode16(case: :lower)
 
     conn =

--- a/test/support/fixtures/builds_fixtures.ex
+++ b/test/support/fixtures/builds_fixtures.ex
@@ -23,8 +23,6 @@ defmodule Glossia.BuildsFixtures do
   defp default_build_args() do
     %{
       version: "123",
-      content_source_id: "glossia/glossia",
-      content_source_platform: :github,
       type: :push
     }
   end

--- a/test/support/fixtures/projects_fixtures.ex
+++ b/test/support/fixtures/projects_fixtures.ex
@@ -30,7 +30,7 @@ defmodule Glossia.ProjectsFixtures do
   defp project_fixture_default_attrs() do
     %{
       handle: "handle#{Glossia.TestHelpers.unique_integer()}",
-      content_source_id:
+      id_in_content_source_platform:
         "#{Glossia.TestHelpers.unique_integer()}/#{Glossia.TestHelpers.unique_integer()}",
       content_source_platform: :github,
       account_id: 1

--- a/test/support/fixtures/projects_fixtures.ex
+++ b/test/support/fixtures/projects_fixtures.ex
@@ -30,9 +30,9 @@ defmodule Glossia.ProjectsFixtures do
   defp project_fixture_default_attrs() do
     %{
       handle: "handle#{Glossia.TestHelpers.unique_integer()}",
-      id_in_content_source_platform:
+      id_in_content_platform:
         "#{Glossia.TestHelpers.unique_integer()}/#{Glossia.TestHelpers.unique_integer()}",
-      content_source_platform: :github,
+      content_platform: :github,
       account_id: 1
     }
   end


### PR DESCRIPTION
I recently learned via @mjsesalm that "projects" is often used in the context of localization to refer to the act of localizing a bunch of pieces of context that are usually related to each other. For example, "the launch of a new product", could be a project. Therefore, I don't think we should respect that terminology in the codebase and the product.
This is the first of two renames that renames what we used to call "content source" to "content source platform". In the coming one, I'll rename "project" to "content source". Here are some real examples:

| Content source ID | Content source platform | ID in content source platform |
| --- | ---- | ---- |
| 1 | github | glossia/glossia |
| 2 | gitlab | glossia/glossia |
