### PR TITLE
feat: add kits - shareable translation terminology bundles

### DIFF
--- a/app/lib/glossia/accounts/account.ex
+++ b/app/lib/glossia/accounts/account.ex
@@ -1,6 +1,7 @@
 defmodule Glossia.Accounts.Account do
   use Glossia.Schema
   import Ecto.Changeset
+  import Glossia.Validations
 
   @derive {
     Flop.Schema,
@@ -42,10 +43,7 @@ defmodule Glossia.Accounts.Account do
     |> validate_required([:handle])
     |> validate_inclusion(:type, ["user", "organization"])
     |> validate_inclusion(:visibility, ["private", "public"])
-    |> validate_format(:handle, ~r/^[a-z]([a-z0-9-]*[a-z0-9])?$/,
-      message: "must start with a letter and contain only lowercase letters, numbers, and hyphens"
-    )
-    |> validate_length(:handle, min: 2, max: 39)
+    |> validate_handle(:handle)
     |> validate_not_reserved()
     |> unique_constraint(:handle)
   end

--- a/app/lib/glossia/accounts/glossary_translation.ex
+++ b/app/lib/glossia/accounts/glossary_translation.ex
@@ -1,6 +1,7 @@
 defmodule Glossia.Accounts.GlossaryTranslation do
   use Glossia.Schema
   import Ecto.Changeset
+  import Glossia.Validations
 
   schema "glossary_translations" do
     field :locale, :string
@@ -15,9 +16,7 @@ defmodule Glossia.Accounts.GlossaryTranslation do
     translation
     |> cast(attrs, [:locale, :translation])
     |> validate_required([:locale, :translation])
-    |> validate_format(:locale, ~r/^[a-z]{2}(-[A-Za-z]{2,})?$/,
-      message: "must be a valid locale like 'en', 'ja', 'es-MX'"
-    )
+    |> validate_locale(:locale)
     |> unique_constraint([:glossary_entry_id, :locale])
   end
 end

--- a/app/lib/glossia/accounts/project.ex
+++ b/app/lib/glossia/accounts/project.ex
@@ -1,6 +1,7 @@
 defmodule Glossia.Accounts.Project do
   use Glossia.Schema
   import Ecto.Changeset
+  import Glossia.Validations
 
   @derive {
     Flop.Schema,
@@ -42,10 +43,7 @@ defmodule Glossia.Accounts.Project do
       :setup_target_languages
     ])
     |> validate_required([:handle, :name])
-    |> validate_format(:handle, ~r/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
-      message: "must contain only lowercase letters, numbers, and hyphens"
-    )
-    |> validate_length(:handle, min: 2, max: 39)
+    |> validate_handle(:handle)
     |> validate_inclusion(:setup_status, ~w(pending running completed failed),
       message: "is invalid"
     )

--- a/app/lib/glossia/accounts/voice_override.ex
+++ b/app/lib/glossia/accounts/voice_override.ex
@@ -1,6 +1,7 @@
 defmodule Glossia.Accounts.VoiceOverride do
   use Glossia.Schema
   import Ecto.Changeset
+  import Glossia.Validations
 
   schema "voice_overrides" do
     field :locale, :string
@@ -18,9 +19,7 @@ defmodule Glossia.Accounts.VoiceOverride do
     override
     |> cast(attrs, [:locale, :tone, :formality, :target_audience, :guidelines])
     |> validate_required([:locale])
-    |> validate_format(:locale, ~r/^[a-z]{2}(-[A-Za-z]{2,})?$/,
-      message: "must be a valid locale like 'en', 'ja', 'es-MX'"
-    )
+    |> validate_locale(:locale)
     |> validate_inclusion(:tone, ~w(casual formal playful authoritative neutral))
     |> validate_inclusion(:formality, ~w(informal neutral formal very_formal))
     |> unique_constraint([:voice_id, :locale])

--- a/app/lib/glossia/kits.ex
+++ b/app/lib/glossia/kits.ex
@@ -1,0 +1,255 @@
+defmodule Glossia.Kits do
+  @moduledoc """
+  Context for managing kits: shareable translation terminology bundles.
+  """
+
+  require OpenTelemetry.Tracer, as: Tracer
+
+  import Ecto.Query
+
+  alias Glossia.Repo
+  alias Glossia.Accounts.{Account, User}
+  alias Glossia.Kits.{Kit, KitEntry, KitEntryTranslation, KitStar}
+
+  @entry_preloads [:translations]
+  @kit_preloads [:created_by, :account, entries: @entry_preloads]
+
+  # --- Kits ---
+
+  def list_kits(%Account{} = account, params \\ %{}) do
+    query =
+      from k in Kit,
+        where: k.account_id == ^account.id,
+        preload: [:created_by]
+
+    Flop.validate_and_run(query, params, for: Kit)
+  end
+
+  def list_public_kits(%Account{} = account, params \\ %{}) do
+    query =
+      from k in Kit,
+        where: k.account_id == ^account.id and k.visibility == "public",
+        preload: [:created_by]
+
+    Flop.validate_and_run(query, params, for: Kit)
+  end
+
+  def get_kit!(id) do
+    Repo.one!(
+      from k in Kit,
+        where: k.id == ^id,
+        preload: ^@kit_preloads
+    )
+  end
+
+  def get_kit_by_handle(%Account{} = account, handle) do
+    Repo.one(
+      from k in Kit,
+        where: k.account_id == ^account.id and k.handle == ^handle,
+        preload: ^@kit_preloads
+    )
+  end
+
+  def create_kit(%Account{} = account, %User{} = user, attrs) do
+    Tracer.with_span "glossia.kits.create_kit" do
+      Tracer.set_attributes([
+        {"glossia.account.id", to_string(account.id)},
+        {"glossia.user.id", to_string(user.id)}
+      ])
+
+      %Kit{}
+      |> Kit.changeset(attrs)
+      |> Ecto.Changeset.put_change(:account_id, account.id)
+      |> Ecto.Changeset.put_change(:created_by_id, user.id)
+      |> Repo.insert()
+    end
+  end
+
+  def update_kit(%Kit{} = kit, attrs) do
+    Tracer.with_span "glossia.kits.update_kit" do
+      Tracer.set_attributes([{"glossia.kit.id", to_string(kit.id)}])
+
+      kit
+      |> Kit.changeset(attrs)
+      |> Repo.update()
+    end
+  end
+
+  def delete_kit(%Kit{} = kit) do
+    Tracer.with_span "glossia.kits.delete_kit" do
+      Tracer.set_attributes([{"glossia.kit.id", to_string(kit.id)}])
+      Repo.delete(kit)
+    end
+  end
+
+  def change_kit(attrs \\ %{}) do
+    Kit.changeset(%Kit{}, attrs)
+  end
+
+  # --- Entries ---
+
+  def add_entry(%Kit{} = kit, attrs) do
+    Tracer.with_span "glossia.kits.add_entry" do
+      Tracer.set_attributes([{"glossia.kit.id", to_string(kit.id)}])
+
+      translations = Map.get(attrs, "translations") || Map.get(attrs, :translations) || []
+
+      Repo.transaction(fn ->
+        entry_result =
+          %KitEntry{}
+          |> KitEntry.changeset(attrs)
+          |> Ecto.Changeset.put_change(:kit_id, kit.id)
+          |> Repo.insert()
+
+        case entry_result do
+          {:ok, entry} ->
+            translations =
+              Enum.map(translations, fn t_attrs ->
+                {:ok, translation} =
+                  %KitEntryTranslation{}
+                  |> KitEntryTranslation.changeset(t_attrs)
+                  |> Ecto.Changeset.put_change(:kit_entry_id, entry.id)
+                  |> Repo.insert()
+
+                translation
+              end)
+
+            %{entry | translations: translations}
+
+          {:error, changeset} ->
+            Repo.rollback({:validation, changeset})
+        end
+      end)
+      |> case do
+        {:ok, entry} -> {:ok, entry}
+        {:error, {:validation, changeset}} -> {:error, changeset}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  def update_entry(%KitEntry{} = entry, attrs) do
+    Tracer.with_span "glossia.kits.update_entry" do
+      Tracer.set_attributes([{"glossia.kit_entry.id", to_string(entry.id)}])
+
+      translations = Map.get(attrs, "translations") || Map.get(attrs, :translations)
+
+      Repo.transaction(fn ->
+        entry_result =
+          entry
+          |> KitEntry.changeset(attrs)
+          |> Repo.update()
+
+        case entry_result do
+          {:ok, updated_entry} ->
+            if translations do
+              # Delete existing translations and re-insert
+              from(t in KitEntryTranslation, where: t.kit_entry_id == ^updated_entry.id)
+              |> Repo.delete_all()
+
+              new_translations =
+                Enum.map(translations, fn t_attrs ->
+                  {:ok, translation} =
+                    %KitEntryTranslation{}
+                    |> KitEntryTranslation.changeset(t_attrs)
+                    |> Ecto.Changeset.put_change(:kit_entry_id, updated_entry.id)
+                    |> Repo.insert()
+
+                  translation
+                end)
+
+              %{updated_entry | translations: new_translations}
+            else
+              Repo.preload(updated_entry, :translations)
+            end
+
+          {:error, changeset} ->
+            Repo.rollback({:validation, changeset})
+        end
+      end)
+      |> case do
+        {:ok, entry} -> {:ok, entry}
+        {:error, {:validation, changeset}} -> {:error, changeset}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  def delete_entry(%KitEntry{} = entry) do
+    Tracer.with_span "glossia.kits.delete_entry" do
+      Tracer.set_attributes([{"glossia.kit_entry.id", to_string(entry.id)}])
+      Repo.delete(entry)
+    end
+  end
+
+  def get_entry!(id) do
+    Repo.one!(
+      from e in KitEntry,
+        where: e.id == ^id,
+        preload: ^@entry_preloads
+    )
+  end
+
+  # --- Stars ---
+
+  def star_kit(%Kit{} = kit, %User{} = user) do
+    Tracer.with_span "glossia.kits.star_kit" do
+      Repo.transaction(fn ->
+        star_result =
+          %KitStar{}
+          |> KitStar.changeset(%{})
+          |> Ecto.Changeset.put_change(:kit_id, kit.id)
+          |> Ecto.Changeset.put_change(:user_id, user.id)
+          |> Repo.insert()
+
+        case star_result do
+          {:ok, star} ->
+            from(k in Kit, where: k.id == ^kit.id)
+            |> Repo.update_all(inc: [stars_count: 1])
+
+            star
+
+          {:error, changeset} ->
+            Repo.rollback({:validation, changeset})
+        end
+      end)
+      |> case do
+        {:ok, star} -> {:ok, star}
+        {:error, {:validation, changeset}} -> {:error, changeset}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  def unstar_kit(%Kit{} = kit, %User{} = user) do
+    Tracer.with_span "glossia.kits.unstar_kit" do
+      star =
+        Repo.one(
+          from s in KitStar,
+            where: s.kit_id == ^kit.id and s.user_id == ^user.id
+        )
+
+      case star do
+        nil ->
+          {:error, :not_found}
+
+        %KitStar{} = star ->
+          Repo.transaction(fn ->
+            Repo.delete!(star)
+
+            from(k in Kit, where: k.id == ^kit.id)
+            |> Repo.update_all(inc: [stars_count: -1])
+
+            :ok
+          end)
+      end
+    end
+  end
+
+  def starred_by?(%Kit{} = kit, %User{} = user) do
+    Repo.exists?(
+      from s in KitStar,
+        where: s.kit_id == ^kit.id and s.user_id == ^user.id
+    )
+  end
+end

--- a/app/lib/glossia/kits.ex
+++ b/app/lib/glossia/kits.ex
@@ -14,40 +14,57 @@ defmodule Glossia.Kits do
   @entry_preloads [:translations]
   @kit_preloads [:created_by, :account, entries: @entry_preloads]
 
+  defp with_stars_count(query) do
+    stars_subquery =
+      from s in KitStar,
+        where: s.kit_id == parent_as(:kit).id,
+        select: count(s.id)
+
+    from k in query,
+      as: :kit,
+      select_merge: %{stars_count: subquery(stars_subquery)}
+  end
+
   # --- Kits ---
 
   def list_kits(%Account{} = account, params \\ %{}) do
     query =
-      from k in Kit,
+      from(k in Kit,
         where: k.account_id == ^account.id,
         preload: [:created_by]
+      )
+      |> with_stars_count()
 
     Flop.validate_and_run(query, params, for: Kit)
   end
 
   def list_public_kits(%Account{} = account, params \\ %{}) do
     query =
-      from k in Kit,
+      from(k in Kit,
         where: k.account_id == ^account.id and k.visibility == "public",
         preload: [:created_by]
+      )
+      |> with_stars_count()
 
     Flop.validate_and_run(query, params, for: Kit)
   end
 
   def get_kit!(id) do
-    Repo.one!(
-      from k in Kit,
-        where: k.id == ^id,
-        preload: ^@kit_preloads
+    from(k in Kit,
+      where: k.id == ^id,
+      preload: ^@kit_preloads
     )
+    |> with_stars_count()
+    |> Repo.one!()
   end
 
   def get_kit_by_handle(%Account{} = account, handle) do
-    Repo.one(
-      from k in Kit,
-        where: k.account_id == ^account.id and k.handle == ^handle,
-        preload: ^@kit_preloads
+    from(k in Kit,
+      where: k.account_id == ^account.id and k.handle == ^handle,
+      preload: ^@kit_preloads
     )
+    |> with_stars_count()
+    |> Repo.one()
   end
 
   def create_kit(%Account{} = account, %User{} = user, attrs) do
@@ -194,54 +211,19 @@ defmodule Glossia.Kits do
 
   def star_kit(%Kit{} = kit, %User{} = user) do
     Tracer.with_span "glossia.kits.star_kit" do
-      Repo.transaction(fn ->
-        star_result =
-          %KitStar{}
-          |> KitStar.changeset(%{})
-          |> Ecto.Changeset.put_change(:kit_id, kit.id)
-          |> Ecto.Changeset.put_change(:user_id, user.id)
-          |> Repo.insert()
-
-        case star_result do
-          {:ok, star} ->
-            from(k in Kit, where: k.id == ^kit.id)
-            |> Repo.update_all(inc: [stars_count: 1])
-
-            star
-
-          {:error, changeset} ->
-            Repo.rollback({:validation, changeset})
-        end
-      end)
-      |> case do
-        {:ok, star} -> {:ok, star}
-        {:error, {:validation, changeset}} -> {:error, changeset}
-        {:error, reason} -> {:error, reason}
-      end
+      %KitStar{}
+      |> KitStar.changeset(%{})
+      |> Ecto.Changeset.put_change(:kit_id, kit.id)
+      |> Ecto.Changeset.put_change(:user_id, user.id)
+      |> Repo.insert()
     end
   end
 
   def unstar_kit(%Kit{} = kit, %User{} = user) do
     Tracer.with_span "glossia.kits.unstar_kit" do
-      star =
-        Repo.one(
-          from s in KitStar,
-            where: s.kit_id == ^kit.id and s.user_id == ^user.id
-        )
-
-      case star do
-        nil ->
-          {:error, :not_found}
-
-        %KitStar{} = star ->
-          Repo.transaction(fn ->
-            Repo.delete!(star)
-
-            from(k in Kit, where: k.id == ^kit.id)
-            |> Repo.update_all(inc: [stars_count: -1])
-
-            :ok
-          end)
+      case Repo.one(from s in KitStar, where: s.kit_id == ^kit.id and s.user_id == ^user.id) do
+        nil -> {:error, :not_found}
+        %KitStar{} = star -> Repo.delete(star)
       end
     end
   end

--- a/app/lib/glossia/kits.ex
+++ b/app/lib/glossia/kits.ex
@@ -9,10 +9,10 @@ defmodule Glossia.Kits do
 
   alias Glossia.Repo
   alias Glossia.Accounts.{Account, User}
-  alias Glossia.Kits.{Kit, KitEntry, KitEntryTranslation, KitStar}
+  alias Glossia.Kits.{Kit, KitTerm, KitTermTranslation, KitStar}
 
-  @entry_preloads [:translations]
-  @kit_preloads [:created_by, :account, entries: @entry_preloads]
+  @term_preloads [:translations]
+  @kit_preloads [:created_by, :account, terms: @term_preloads]
 
   defp with_stars_count(query) do
     stars_subquery =
@@ -103,81 +103,80 @@ defmodule Glossia.Kits do
     Kit.changeset(%Kit{}, attrs)
   end
 
-  # --- Entries ---
+  # --- Terms ---
 
-  def add_entry(%Kit{} = kit, attrs) do
-    Tracer.with_span "glossia.kits.add_entry" do
+  def add_term(%Kit{} = kit, attrs) do
+    Tracer.with_span "glossia.kits.add_term" do
       Tracer.set_attributes([{"glossia.kit.id", to_string(kit.id)}])
 
       translations = Map.get(attrs, "translations") || Map.get(attrs, :translations) || []
 
       Repo.transaction(fn ->
-        entry_result =
-          %KitEntry{}
-          |> KitEntry.changeset(attrs)
+        term_result =
+          %KitTerm{}
+          |> KitTerm.changeset(attrs)
           |> Ecto.Changeset.put_change(:kit_id, kit.id)
           |> Repo.insert()
 
-        case entry_result do
-          {:ok, entry} ->
+        case term_result do
+          {:ok, term} ->
             translations =
               Enum.map(translations, fn t_attrs ->
                 {:ok, translation} =
-                  %KitEntryTranslation{}
-                  |> KitEntryTranslation.changeset(t_attrs)
-                  |> Ecto.Changeset.put_change(:kit_entry_id, entry.id)
+                  %KitTermTranslation{}
+                  |> KitTermTranslation.changeset(t_attrs)
+                  |> Ecto.Changeset.put_change(:kit_term_id, term.id)
                   |> Repo.insert()
 
                 translation
               end)
 
-            %{entry | translations: translations}
+            %{term | translations: translations}
 
           {:error, changeset} ->
             Repo.rollback({:validation, changeset})
         end
       end)
       |> case do
-        {:ok, entry} -> {:ok, entry}
+        {:ok, term} -> {:ok, term}
         {:error, {:validation, changeset}} -> {:error, changeset}
         {:error, reason} -> {:error, reason}
       end
     end
   end
 
-  def update_entry(%KitEntry{} = entry, attrs) do
-    Tracer.with_span "glossia.kits.update_entry" do
-      Tracer.set_attributes([{"glossia.kit_entry.id", to_string(entry.id)}])
+  def update_term(%KitTerm{} = term, attrs) do
+    Tracer.with_span "glossia.kits.update_term" do
+      Tracer.set_attributes([{"glossia.kit_term.id", to_string(term.id)}])
 
       translations = Map.get(attrs, "translations") || Map.get(attrs, :translations)
 
       Repo.transaction(fn ->
-        entry_result =
-          entry
-          |> KitEntry.changeset(attrs)
+        term_result =
+          term
+          |> KitTerm.changeset(attrs)
           |> Repo.update()
 
-        case entry_result do
-          {:ok, updated_entry} ->
+        case term_result do
+          {:ok, updated_term} ->
             if translations do
-              # Delete existing translations and re-insert
-              from(t in KitEntryTranslation, where: t.kit_entry_id == ^updated_entry.id)
+              from(t in KitTermTranslation, where: t.kit_term_id == ^updated_term.id)
               |> Repo.delete_all()
 
               new_translations =
                 Enum.map(translations, fn t_attrs ->
                   {:ok, translation} =
-                    %KitEntryTranslation{}
-                    |> KitEntryTranslation.changeset(t_attrs)
-                    |> Ecto.Changeset.put_change(:kit_entry_id, updated_entry.id)
+                    %KitTermTranslation{}
+                    |> KitTermTranslation.changeset(t_attrs)
+                    |> Ecto.Changeset.put_change(:kit_term_id, updated_term.id)
                     |> Repo.insert()
 
                   translation
                 end)
 
-              %{updated_entry | translations: new_translations}
+              %{updated_term | translations: new_translations}
             else
-              Repo.preload(updated_entry, :translations)
+              Repo.preload(updated_term, :translations)
             end
 
           {:error, changeset} ->
@@ -185,25 +184,25 @@ defmodule Glossia.Kits do
         end
       end)
       |> case do
-        {:ok, entry} -> {:ok, entry}
+        {:ok, term} -> {:ok, term}
         {:error, {:validation, changeset}} -> {:error, changeset}
         {:error, reason} -> {:error, reason}
       end
     end
   end
 
-  def delete_entry(%KitEntry{} = entry) do
-    Tracer.with_span "glossia.kits.delete_entry" do
-      Tracer.set_attributes([{"glossia.kit_entry.id", to_string(entry.id)}])
-      Repo.delete(entry)
+  def delete_term(%KitTerm{} = term) do
+    Tracer.with_span "glossia.kits.delete_term" do
+      Tracer.set_attributes([{"glossia.kit_term.id", to_string(term.id)}])
+      Repo.delete(term)
     end
   end
 
-  def get_entry!(id) do
+  def get_term!(id) do
     Repo.one!(
-      from e in KitEntry,
-        where: e.id == ^id,
-        preload: ^@entry_preloads
+      from t in KitTerm,
+        where: t.id == ^id,
+        preload: ^@term_preloads
     )
   end
 

--- a/app/lib/glossia/kits/kit.ex
+++ b/app/lib/glossia/kits/kit.ex
@@ -6,7 +6,7 @@ defmodule Glossia.Kits.Kit do
   @derive {
     Flop.Schema,
     filterable: [:name, :visibility, :source_language, :inserted_at],
-    sortable: [:name, :source_language, :stars_count, :inserted_at],
+    sortable: [:name, :source_language, :inserted_at],
     default_order: %{order_by: [:inserted_at], order_directions: [:desc]}
   }
 
@@ -20,7 +20,7 @@ defmodule Glossia.Kits.Kit do
     field :target_languages, {:array, :string}, default: []
     field :domain_tags, {:array, :string}, default: []
     field :visibility, :string, default: "public"
-    field :stars_count, :integer, default: 0
+    field :stars_count, :integer, virtual: true, default: 0
 
     belongs_to :account, Glossia.Accounts.Account
     belongs_to :created_by, Glossia.Accounts.User

--- a/app/lib/glossia/kits/kit.ex
+++ b/app/lib/glossia/kits/kit.ex
@@ -1,0 +1,53 @@
+defmodule Glossia.Kits.Kit do
+  use Glossia.Schema
+  import Ecto.Changeset
+
+  @derive {
+    Flop.Schema,
+    filterable: [:name, :visibility, :source_language, :inserted_at],
+    sortable: [:name, :source_language, :stars_count, :inserted_at],
+    default_order: %{order_by: [:inserted_at], order_directions: [:desc]}
+  }
+
+  @visibilities ~w(public private)
+
+  schema "kits" do
+    field :handle, :string
+    field :name, :string
+    field :description, :string
+    field :source_language, :string
+    field :target_languages, {:array, :string}, default: []
+    field :domain_tags, {:array, :string}, default: []
+    field :visibility, :string, default: "public"
+    field :stars_count, :integer, default: 0
+
+    belongs_to :account, Glossia.Accounts.Account
+    belongs_to :created_by, Glossia.Accounts.User
+
+    has_many :entries, Glossia.Kits.KitEntry
+    has_many :stars, Glossia.Kits.KitStar
+
+    timestamps()
+  end
+
+  def changeset(kit, attrs) do
+    kit
+    |> cast(attrs, [
+      :handle,
+      :name,
+      :description,
+      :source_language,
+      :target_languages,
+      :domain_tags,
+      :visibility
+    ])
+    |> validate_required([:handle, :name, :source_language])
+    |> validate_length(:handle, min: 1, max: 64)
+    |> validate_length(:name, min: 1, max: 255)
+    |> validate_format(:handle, ~r/\A[a-z0-9]([a-z0-9-]*[a-z0-9])?\z/,
+      message: "must be lowercase alphanumeric with optional hyphens"
+    )
+    |> validate_inclusion(:visibility, @visibilities)
+    |> unique_constraint([:account_id, :handle])
+  end
+end

--- a/app/lib/glossia/kits/kit.ex
+++ b/app/lib/glossia/kits/kit.ex
@@ -25,7 +25,7 @@ defmodule Glossia.Kits.Kit do
     belongs_to :account, Glossia.Accounts.Account
     belongs_to :created_by, Glossia.Accounts.User
 
-    has_many :entries, Glossia.Kits.KitEntry
+    has_many :terms, Glossia.Kits.KitTerm
     has_many :stars, Glossia.Kits.KitStar
 
     timestamps()

--- a/app/lib/glossia/kits/kit.ex
+++ b/app/lib/glossia/kits/kit.ex
@@ -1,6 +1,7 @@
 defmodule Glossia.Kits.Kit do
   use Glossia.Schema
   import Ecto.Changeset
+  import Glossia.Validations
 
   @derive {
     Flop.Schema,
@@ -42,11 +43,10 @@ defmodule Glossia.Kits.Kit do
       :visibility
     ])
     |> validate_required([:handle, :name, :source_language])
-    |> validate_length(:handle, min: 1, max: 64)
+    |> validate_handle(:handle, min: 1, max: 64)
+    |> validate_locale(:source_language)
+    |> validate_locales(:target_languages)
     |> validate_length(:name, min: 1, max: 255)
-    |> validate_format(:handle, ~r/\A[a-z0-9]([a-z0-9-]*[a-z0-9])?\z/,
-      message: "must be lowercase alphanumeric with optional hyphens"
-    )
     |> validate_inclusion(:visibility, @visibilities)
     |> unique_constraint([:account_id, :handle])
   end

--- a/app/lib/glossia/kits/kit_entry.ex
+++ b/app/lib/glossia/kits/kit_entry.ex
@@ -1,0 +1,24 @@
+defmodule Glossia.Kits.KitEntry do
+  use Glossia.Schema
+  import Ecto.Changeset
+
+  schema "kit_entries" do
+    field :source_term, :string
+    field :definition, :string
+    field :tags, {:array, :string}, default: []
+
+    belongs_to :kit, Glossia.Kits.Kit
+
+    has_many :translations, Glossia.Kits.KitEntryTranslation
+
+    timestamps()
+  end
+
+  def changeset(entry, attrs) do
+    entry
+    |> cast(attrs, [:source_term, :definition, :tags])
+    |> validate_required([:source_term])
+    |> validate_length(:source_term, min: 1, max: 255)
+    |> unique_constraint([:kit_id, :source_term])
+  end
+end

--- a/app/lib/glossia/kits/kit_entry_translation.ex
+++ b/app/lib/glossia/kits/kit_entry_translation.ex
@@ -1,0 +1,23 @@
+defmodule Glossia.Kits.KitEntryTranslation do
+  use Glossia.Schema
+  import Ecto.Changeset
+
+  schema "kit_entry_translations" do
+    field :language, :string
+    field :translated_term, :string
+    field :usage_note, :string
+
+    belongs_to :kit_entry, Glossia.Kits.KitEntry
+
+    timestamps()
+  end
+
+  def changeset(translation, attrs) do
+    translation
+    |> cast(attrs, [:language, :translated_term, :usage_note])
+    |> validate_required([:language, :translated_term])
+    |> validate_length(:language, min: 2, max: 35)
+    |> validate_length(:translated_term, min: 1, max: 500)
+    |> unique_constraint([:kit_entry_id, :language])
+  end
+end

--- a/app/lib/glossia/kits/kit_entry_translation.ex
+++ b/app/lib/glossia/kits/kit_entry_translation.ex
@@ -1,6 +1,7 @@
 defmodule Glossia.Kits.KitEntryTranslation do
   use Glossia.Schema
   import Ecto.Changeset
+  import Glossia.Validations
 
   schema "kit_entry_translations" do
     field :language, :string
@@ -16,7 +17,7 @@ defmodule Glossia.Kits.KitEntryTranslation do
     translation
     |> cast(attrs, [:language, :translated_term, :usage_note])
     |> validate_required([:language, :translated_term])
-    |> validate_length(:language, min: 2, max: 35)
+    |> validate_locale(:language)
     |> validate_length(:translated_term, min: 1, max: 500)
     |> unique_constraint([:kit_entry_id, :language])
   end

--- a/app/lib/glossia/kits/kit_star.ex
+++ b/app/lib/glossia/kits/kit_star.ex
@@ -1,0 +1,17 @@
+defmodule Glossia.Kits.KitStar do
+  use Glossia.Schema
+  import Ecto.Changeset
+
+  schema "kit_stars" do
+    belongs_to :kit, Glossia.Kits.Kit
+    belongs_to :user, Glossia.Accounts.User
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(star, attrs) do
+    star
+    |> cast(attrs, [])
+    |> unique_constraint([:kit_id, :user_id])
+  end
+end

--- a/app/lib/glossia/kits/kit_term.ex
+++ b/app/lib/glossia/kits/kit_term.ex
@@ -1,21 +1,21 @@
-defmodule Glossia.Kits.KitEntry do
+defmodule Glossia.Kits.KitTerm do
   use Glossia.Schema
   import Ecto.Changeset
 
-  schema "kit_entries" do
+  schema "kit_terms" do
     field :source_term, :string
     field :definition, :string
     field :tags, {:array, :string}, default: []
 
     belongs_to :kit, Glossia.Kits.Kit
 
-    has_many :translations, Glossia.Kits.KitEntryTranslation
+    has_many :translations, Glossia.Kits.KitTermTranslation
 
     timestamps()
   end
 
-  def changeset(entry, attrs) do
-    entry
+  def changeset(term, attrs) do
+    term
     |> cast(attrs, [:source_term, :definition, :tags])
     |> validate_required([:source_term])
     |> validate_length(:source_term, min: 1, max: 255)

--- a/app/lib/glossia/kits/kit_term_translation.ex
+++ b/app/lib/glossia/kits/kit_term_translation.ex
@@ -1,14 +1,14 @@
-defmodule Glossia.Kits.KitEntryTranslation do
+defmodule Glossia.Kits.KitTermTranslation do
   use Glossia.Schema
   import Ecto.Changeset
   import Glossia.Validations
 
-  schema "kit_entry_translations" do
+  schema "kit_term_translations" do
     field :language, :string
     field :translated_term, :string
     field :usage_note, :string
 
-    belongs_to :kit_entry, Glossia.Kits.KitEntry
+    belongs_to :kit_term, Glossia.Kits.KitTerm
 
     timestamps()
   end
@@ -19,6 +19,6 @@ defmodule Glossia.Kits.KitEntryTranslation do
     |> validate_required([:language, :translated_term])
     |> validate_locale(:language)
     |> validate_length(:translated_term, min: 1, max: 500)
-    |> unique_constraint([:kit_entry_id, :language])
+    |> unique_constraint([:kit_term_id, :language])
   end
 end

--- a/app/lib/glossia/mcp/get_kit_tool.ex
+++ b/app/lib/glossia/mcp/get_kit_tool.ex
@@ -1,0 +1,68 @@
+defmodule Glossia.MCP.GetKitTool do
+  @moduledoc "Get a translation terminology kit by handle, including all entries and translations."
+
+  use Hermes.Server.Component, type: :tool
+
+  alias Glossia.Kits
+  alias Glossia.MCP.Authorization, as: Auth
+  alias Hermes.Server.Response
+
+  schema do
+    field :handle, {:required, :string}, description: "Account handle."
+    field :kit_handle, {:required, :string}, description: "Kit handle within the account."
+  end
+
+  @impl true
+  def execute(params, frame) do
+    handle = params["handle"]
+    kit_handle = params["kit_handle"]
+
+    with {:ok, user} <- Auth.current_user(frame),
+         {:ok, account} <- Auth.fetch_account(handle),
+         :ok <- Auth.authorize(frame, :kit_read, user, account) do
+      case Kits.get_kit_by_handle(account, kit_handle) do
+        nil ->
+          {:error, Hermes.MCP.Error.execution("Kit '#{kit_handle}' not found for '#{handle}'"),
+           frame}
+
+        kit ->
+          serialized = %{
+            handle: kit.handle,
+            name: kit.name,
+            description: kit.description,
+            source_language: kit.source_language,
+            target_languages: kit.target_languages,
+            domain_tags: kit.domain_tags,
+            visibility: kit.visibility,
+            stars_count: kit.stars_count,
+            inserted_at: kit.inserted_at,
+            entries:
+              Enum.map(kit.entries, fn entry ->
+                %{
+                  id: entry.id,
+                  source_term: entry.source_term,
+                  definition: entry.definition,
+                  tags: entry.tags,
+                  translations:
+                    Enum.map(entry.translations, fn t ->
+                      %{
+                        language: t.language,
+                        translated_term: t.translated_term,
+                        usage_note: t.usage_note
+                      }
+                    end)
+                }
+              end)
+          }
+
+          response =
+            Response.tool()
+            |> Response.text(JSON.encode!(serialized))
+
+          {:reply, response, frame}
+      end
+    else
+      {:error, error} -> {:error, error, frame}
+    end
+  end
+end

--- a/app/lib/glossia/mcp/get_kit_tool.ex
+++ b/app/lib/glossia/mcp/get_kit_tool.ex
@@ -1,5 +1,5 @@
 defmodule Glossia.MCP.GetKitTool do
-  @moduledoc "Get a translation terminology kit by handle, including all entries and translations."
+  @moduledoc "Get a translation terminology kit by handle, including all terms and translations."
 
   use Hermes.Server.Component, type: :tool
 
@@ -36,15 +36,15 @@ defmodule Glossia.MCP.GetKitTool do
             visibility: kit.visibility,
             stars_count: kit.stars_count,
             inserted_at: kit.inserted_at,
-            entries:
-              Enum.map(kit.entries, fn entry ->
+            terms:
+              Enum.map(kit.terms, fn term ->
                 %{
-                  id: entry.id,
-                  source_term: entry.source_term,
-                  definition: entry.definition,
-                  tags: entry.tags,
+                  id: term.id,
+                  source_term: term.source_term,
+                  definition: term.definition,
+                  tags: term.tags,
                   translations:
-                    Enum.map(entry.translations, fn t ->
+                    Enum.map(term.translations, fn t ->
                       %{
                         language: t.language,
                         translated_term: t.translated_term,

--- a/app/lib/glossia/mcp/list_kits_tool.ex
+++ b/app/lib/glossia/mcp/list_kits_tool.ex
@@ -1,0 +1,51 @@
+defmodule Glossia.MCP.ListKitsTool do
+  @moduledoc "List translation terminology kits for an account."
+
+  use Hermes.Server.Component, type: :tool
+
+  alias Glossia.Kits
+  alias Glossia.MCP.Authorization, as: Auth
+  alias Hermes.Server.Response
+
+  schema do
+    field :handle, {:required, :string}, description: "Account handle to list kits for."
+  end
+
+  @impl true
+  def execute(params, frame) do
+    handle = params["handle"]
+
+    with {:ok, user} <- Auth.current_user(frame),
+         {:ok, account} <- Auth.fetch_account(handle),
+         :ok <- Auth.authorize(frame, :kit_read, user, account) do
+      case Kits.list_kits(account) do
+        {:ok, {kits, _meta}} ->
+          serialized =
+            Enum.map(kits, fn kit ->
+              %{
+                handle: kit.handle,
+                name: kit.name,
+                description: kit.description,
+                source_language: kit.source_language,
+                target_languages: kit.target_languages,
+                domain_tags: kit.domain_tags,
+                visibility: kit.visibility,
+                stars_count: kit.stars_count,
+                inserted_at: kit.inserted_at
+              }
+            end)
+
+          response =
+            Response.tool()
+            |> Response.text(JSON.encode!(serialized))
+
+          {:reply, response, frame}
+
+        {:error, _} ->
+          {:error, Hermes.MCP.Error.execution("Failed to list kits"), frame}
+      end
+    else
+      {:error, error} -> {:error, error, frame}
+    end
+  end
+end

--- a/app/lib/glossia/mcp/server.ex
+++ b/app/lib/glossia/mcp/server.ex
@@ -25,4 +25,6 @@ defmodule Glossia.MCP.Server do
   component(Glossia.MCP.CreateTokenTool, name: "create_token")
   component(Glossia.MCP.RevokeTokenTool, name: "revoke_token")
   component(Glossia.MCP.ListOAuthAppsTool, name: "list_oauth_apps")
+  component(Glossia.MCP.ListKitsTool, name: "list_kits")
+  component(Glossia.MCP.GetKitTool, name: "get_kit")
 end

--- a/app/lib/glossia/policy.ex
+++ b/app/lib/glossia/policy.ex
@@ -192,6 +192,34 @@ defmodule Glossia.Policy do
     end
   end
 
+  object :kit do
+    action :read do
+      allow(:super_admin)
+      allow(:account_owner)
+      allow(:organization_admin)
+      allow(:organization_member)
+      allow(:public_account)
+    end
+
+    action :write do
+      deny(:no_access)
+      allow(:account_owner)
+      allow(:organization_admin)
+    end
+
+    action :admin do
+      deny(:no_access)
+      allow(:account_owner)
+      allow(:organization_admin)
+    end
+
+    action :delete do
+      deny(:no_access)
+      allow(:account_owner)
+      allow(:organization_admin)
+    end
+  end
+
   object :api_credentials do
     action :read do
       allow(:super_admin)

--- a/app/lib/glossia/validations.ex
+++ b/app/lib/glossia/validations.ex
@@ -1,0 +1,58 @@
+defmodule Glossia.Validations do
+  @moduledoc """
+  Shared changeset validations reused across schemas.
+  """
+
+  import Ecto.Changeset
+
+  @locale_regex ~r/^[a-z]{2}(-[A-Za-z]{2,})?$/
+  @handle_regex ~r/^[a-z]([a-z0-9-]*[a-z0-9])?$/
+
+  @doc """
+  Validates that a field contains a valid locale string (BCP 47-like).
+
+  Accepts values like "en", "ja", "es-MX", "pt-BR".
+  """
+  def validate_locale(changeset, field) do
+    changeset
+    |> validate_format(field, @locale_regex,
+      message: "must be a valid locale like 'en', 'ja', 'es-MX'"
+    )
+  end
+
+  @doc """
+  Validates that an array field contains only valid locale strings.
+
+  Each element must match the same BCP 47-like pattern as `validate_locale/2`.
+  """
+  def validate_locales(changeset, field) do
+    validate_change(changeset, field, fn _, values ->
+      invalid =
+        Enum.reject(values, fn v ->
+          is_binary(v) and Regex.match?(@locale_regex, v)
+        end)
+
+      if invalid == [] do
+        []
+      else
+        [{field, "contains invalid locales: #{Enum.join(invalid, ", ")}"}]
+      end
+    end)
+  end
+
+  @doc """
+  Validates that a field contains a valid handle.
+
+  Must start with a letter and contain only lowercase letters, numbers, and hyphens.
+  """
+  def validate_handle(changeset, field, opts \\ []) do
+    min = Keyword.get(opts, :min, 2)
+    max = Keyword.get(opts, :max, 39)
+
+    changeset
+    |> validate_format(field, @handle_regex,
+      message: "must start with a letter and contain only lowercase letters, numbers, and hyphens"
+    )
+    |> validate_length(field, min: min, max: max)
+  end
+end

--- a/app/lib/glossia_web/components/layouts/platform.html.heex
+++ b/app/lib/glossia_web/components/layouts/platform.html.heex
@@ -246,6 +246,37 @@
                 <span>{gettext("Glossary")}</span>
               </.link>
             <% end %>
+            <%= if @can_kit_read or @can_kit_write do %>
+              <.link
+                navigate={"/#{@handle}/-/kits"}
+                class={[
+                  "gl-nav-item",
+                  @live_action in [
+                    :kits,
+                    :kit_new,
+                    :kit_show,
+                    :kit_edit,
+                    :kit_entry_new,
+                    :kit_entry_edit
+                  ] && "active"
+                ]}
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="m7.5 4.27 9 5.15" /><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" /><path d="m3.3 7 8.7 5 8.7-5" /><path d="M12 22V12" />
+                </svg>
+                <span>{gettext("Kits")}</span>
+              </.link>
+            <% end %>
             <.link
               navigate={"/#{@handle}/-/discussions"}
               class={[

--- a/app/lib/glossia_web/controllers/api/kit_api_controller.ex
+++ b/app/lib/glossia_web/controllers/api/kit_api_controller.ex
@@ -48,7 +48,7 @@ defmodule GlossiaWeb.Api.KitApiController do
                 conn |> put_status(:not_found) |> json(%{error: "kit not found"})
 
               kit ->
-                json(conn, serialize_kit_with_entries(kit))
+                json(conn, serialize_kit_with_terms(kit))
             end
 
           {:error, conn} ->
@@ -92,7 +92,7 @@ defmodule GlossiaWeb.Api.KitApiController do
     end
   end
 
-  def create_entry(conn, %{"handle" => handle, "kit_handle" => kit_handle} = params) do
+  def create_term(conn, %{"handle" => handle, "kit_handle" => kit_handle} = params) do
     case Accounts.get_account_by_handle(handle) do
       nil ->
         conn |> put_status(:not_found) |> json(%{error: "account not found"})
@@ -107,18 +107,18 @@ defmodule GlossiaWeb.Api.KitApiController do
               kit ->
                 user = conn.assigns[:current_user]
 
-                case Kits.add_entry(kit, params) do
-                  {:ok, entry} ->
-                    Auditing.record("kit_entry.created", account, user,
-                      resource_type: "kit_entry",
-                      resource_id: to_string(entry.id),
+                case Kits.add_term(kit, params) do
+                  {:ok, term} ->
+                    Auditing.record("kit_term.created", account, user,
+                      resource_type: "kit_term",
+                      resource_id: to_string(term.id),
                       resource_path: "/#{handle}/kits/#{kit.handle}",
-                      summary: "Added entry \"#{entry.source_term}\" to kit #{kit.handle} via API"
+                      summary: "Added term \"#{term.source_term}\" to kit #{kit.handle} via API"
                     )
 
                     conn
                     |> put_status(:created)
-                    |> json(serialize_entry(entry))
+                    |> json(serialize_term(term))
 
                   {:error, changeset} ->
                     conn
@@ -147,27 +147,27 @@ defmodule GlossiaWeb.Api.KitApiController do
     }
   end
 
-  defp serialize_kit_with_entries(kit) do
+  defp serialize_kit_with_terms(kit) do
     kit
     |> serialize_kit()
-    |> Map.put(:entries, Enum.map(kit.entries, &serialize_entry/1))
+    |> Map.put(:terms, Enum.map(kit.terms, &serialize_term/1))
   end
 
-  defp serialize_entry(entry) do
+  defp serialize_term(term) do
     %{
-      id: entry.id,
-      source_term: entry.source_term,
-      definition: entry.definition,
-      tags: entry.tags,
+      id: term.id,
+      source_term: term.source_term,
+      definition: term.definition,
+      tags: term.tags,
       translations:
-        Enum.map(entry.translations, fn t ->
+        Enum.map(term.translations, fn t ->
           %{
             language: t.language,
             translated_term: t.translated_term,
             usage_note: t.usage_note
           }
         end),
-      inserted_at: entry.inserted_at
+      inserted_at: term.inserted_at
     }
   end
 end

--- a/app/lib/glossia_web/controllers/api/kit_api_controller.ex
+++ b/app/lib/glossia_web/controllers/api/kit_api_controller.ex
@@ -1,0 +1,173 @@
+defmodule GlossiaWeb.Api.KitApiController do
+  use GlossiaWeb, :controller
+
+  alias Glossia.Accounts
+  alias Glossia.Auditing
+  alias Glossia.ChangesetErrors
+  alias Glossia.Kits
+  alias GlossiaWeb.Api.Serialization
+  alias GlossiaWeb.ApiAuthorization
+
+  def index(conn, %{"handle" => handle} = params) do
+    case Accounts.get_account_by_handle(handle) do
+      nil ->
+        conn |> put_status(:not_found) |> json(%{error: "account not found"})
+
+      account ->
+        case ApiAuthorization.authorize(conn, :kit_read, account) do
+          {:ok, conn} ->
+            case Kits.list_kits(account, params) do
+              {:ok, {kits, meta}} ->
+                json(conn, %{
+                  kits: Enum.map(kits, &serialize_kit/1),
+                  meta: Serialization.meta(meta)
+                })
+
+              {:error, meta} ->
+                conn
+                |> put_status(:bad_request)
+                |> json(%{errors: meta.errors})
+            end
+
+          {:error, conn} ->
+            conn
+        end
+    end
+  end
+
+  def show(conn, %{"handle" => handle, "kit_handle" => kit_handle}) do
+    case Accounts.get_account_by_handle(handle) do
+      nil ->
+        conn |> put_status(:not_found) |> json(%{error: "account not found"})
+
+      account ->
+        case ApiAuthorization.authorize(conn, :kit_read, account) do
+          {:ok, conn} ->
+            case Kits.get_kit_by_handle(account, kit_handle) do
+              nil ->
+                conn |> put_status(:not_found) |> json(%{error: "kit not found"})
+
+              kit ->
+                json(conn, serialize_kit_with_entries(kit))
+            end
+
+          {:error, conn} ->
+            conn
+        end
+    end
+  end
+
+  def create(conn, %{"handle" => handle} = params) do
+    case Accounts.get_account_by_handle(handle) do
+      nil ->
+        conn |> put_status(:not_found) |> json(%{error: "account not found"})
+
+      account ->
+        case ApiAuthorization.authorize(conn, :kit_write, account) do
+          {:ok, conn} ->
+            user = conn.assigns[:current_user]
+
+            case Kits.create_kit(account, user, params) do
+              {:ok, kit} ->
+                Auditing.record("kit.created", account, user,
+                  resource_type: "kit",
+                  resource_id: to_string(kit.id),
+                  resource_path: "/#{handle}/kits/#{kit.handle}",
+                  summary: "Created kit #{kit.handle} via API"
+                )
+
+                conn
+                |> put_status(:created)
+                |> json(serialize_kit(kit))
+
+              {:error, changeset} ->
+                conn
+                |> put_status(:unprocessable_entity)
+                |> json(%{errors: ChangesetErrors.to_map(changeset)})
+            end
+
+          {:error, conn} ->
+            conn
+        end
+    end
+  end
+
+  def create_entry(conn, %{"handle" => handle, "kit_handle" => kit_handle} = params) do
+    case Accounts.get_account_by_handle(handle) do
+      nil ->
+        conn |> put_status(:not_found) |> json(%{error: "account not found"})
+
+      account ->
+        case ApiAuthorization.authorize(conn, :kit_write, account) do
+          {:ok, conn} ->
+            case Kits.get_kit_by_handle(account, kit_handle) do
+              nil ->
+                conn |> put_status(:not_found) |> json(%{error: "kit not found"})
+
+              kit ->
+                user = conn.assigns[:current_user]
+
+                case Kits.add_entry(kit, params) do
+                  {:ok, entry} ->
+                    Auditing.record("kit_entry.created", account, user,
+                      resource_type: "kit_entry",
+                      resource_id: to_string(entry.id),
+                      resource_path: "/#{handle}/kits/#{kit.handle}",
+                      summary: "Added entry \"#{entry.source_term}\" to kit #{kit.handle} via API"
+                    )
+
+                    conn
+                    |> put_status(:created)
+                    |> json(serialize_entry(entry))
+
+                  {:error, changeset} ->
+                    conn
+                    |> put_status(:unprocessable_entity)
+                    |> json(%{errors: ChangesetErrors.to_map(changeset)})
+                end
+            end
+
+          {:error, conn} ->
+            conn
+        end
+    end
+  end
+
+  defp serialize_kit(kit) do
+    %{
+      handle: kit.handle,
+      name: kit.name,
+      description: kit.description,
+      source_language: kit.source_language,
+      target_languages: kit.target_languages,
+      domain_tags: kit.domain_tags,
+      visibility: kit.visibility,
+      stars_count: kit.stars_count,
+      inserted_at: kit.inserted_at
+    }
+  end
+
+  defp serialize_kit_with_entries(kit) do
+    kit
+    |> serialize_kit()
+    |> Map.put(:entries, Enum.map(kit.entries, &serialize_entry/1))
+  end
+
+  defp serialize_entry(entry) do
+    %{
+      id: entry.id,
+      source_term: entry.source_term,
+      definition: entry.definition,
+      tags: entry.tags,
+      translations:
+        Enum.map(entry.translations, fn t ->
+          %{
+            language: t.language,
+            translated_term: t.translated_term,
+            usage_note: t.usage_note
+          }
+        end),
+      inserted_at: entry.inserted_at
+    }
+  end
+end

--- a/app/lib/glossia_web/live/dashboard_live.ex
+++ b/app/lib/glossia_web/live/dashboard_live.ex
@@ -10176,7 +10176,7 @@ defmodule GlossiaWeb.DashboardLive do
             {kit.visibility}
           </.badge>
         </:col>
-        <:col :let={kit} label={gettext("Stars")} key="stars_count" sortable>
+        <:col :let={kit} label={gettext("Stars")}>
           {kit.stars_count}
         </:col>
         <:col :let={kit} label={gettext("Created")} key="inserted_at" sortable>

--- a/app/lib/glossia_web/live/dashboard_live.ex
+++ b/app/lib/glossia_web/live/dashboard_live.ex
@@ -845,7 +845,7 @@ defmodule GlossiaWeb.DashboardLive do
     )
   end
 
-  defp apply_action(socket, :kit_entry_new, %{"kit_handle" => kit_handle}) do
+  defp apply_action(socket, :kit_term_new, %{"kit_handle" => kit_handle}) do
     require_action!(socket, :kit_write)
     account = socket.assigns.account
     handle = socket.assigns.handle
@@ -857,9 +857,9 @@ defmodule GlossiaWeb.DashboardLive do
     end
 
     assign(socket,
-      page_title: gettext("New entry"),
+      page_title: gettext("New term"),
       kit: kit,
-      entry_form:
+      term_form:
         to_form(
           %{
             "source_term" => "",
@@ -870,18 +870,18 @@ defmodule GlossiaWeb.DashboardLive do
                 %{"language" => lang, "translated_term" => "", "usage_note" => ""}
               end)
           },
-          as: :entry
+          as: :term
         ),
-      entry_form_valid?: false,
+      term_form_valid?: false,
       breadcrumb_items: [
         {gettext("Kits"), "/" <> handle <> "/-/kits"},
         {kit.name, "/" <> handle <> "/-/kits/" <> kit.handle},
-        {gettext("New entry"), nil}
+        {gettext("New term"), nil}
       ]
     )
   end
 
-  defp apply_action(socket, :kit_entry_edit, %{"kit_handle" => kit_handle, "entry_id" => entry_id}) do
+  defp apply_action(socket, :kit_term_edit, %{"kit_handle" => kit_handle, "term_id" => term_id}) do
     require_action!(socket, :kit_write)
     account = socket.assigns.account
     handle = socket.assigns.handle
@@ -892,10 +892,10 @@ defmodule GlossiaWeb.DashboardLive do
       raise Ecto.NoResultsError, queryable: Glossia.Kits.Kit
     end
 
-    entry = Kits.get_entry!(entry_id)
+    term = Kits.get_term!(term_id)
 
     existing_translations =
-      Enum.map(entry.translations, fn t ->
+      Enum.map(term.translations, fn t ->
         %{
           "language" => t.language,
           "translated_term" => t.translated_term,
@@ -903,7 +903,7 @@ defmodule GlossiaWeb.DashboardLive do
         }
       end)
 
-    missing_langs = kit.target_languages -- Enum.map(entry.translations, & &1.language)
+    missing_langs = kit.target_languages -- Enum.map(term.translations, & &1.language)
 
     all_translations =
       existing_translations ++
@@ -912,25 +912,25 @@ defmodule GlossiaWeb.DashboardLive do
         end)
 
     assign(socket,
-      page_title: entry.source_term,
+      page_title: term.source_term,
       kit: kit,
-      entry: entry,
-      entry_form:
+      term: term,
+      term_form:
         to_form(
           %{
-            "source_term" => entry.source_term,
-            "definition" => entry.definition || "",
-            "tags" => entry.tags,
+            "source_term" => term.source_term,
+            "definition" => term.definition || "",
+            "tags" => term.tags,
             "translations" => all_translations
           },
-          as: :entry
+          as: :term
         ),
-      entry_form_valid?: true,
-      entry_edit_changed?: false,
+      term_form_valid?: true,
+      term_edit_changed?: false,
       breadcrumb_items: [
         {gettext("Kits"), "/" <> handle <> "/-/kits"},
         {kit.name, "/" <> handle <> "/-/kits/" <> kit.handle},
-        {entry.source_term, nil}
+        {term.source_term, nil}
       ]
     )
   end
@@ -2330,28 +2330,28 @@ defmodule GlossiaWeb.DashboardLive do
     end
   end
 
-  def handle_event("entry_validate", %{"entry" => params}, socket) do
+  def handle_event("term_validate", %{"term" => params}, socket) do
     valid? = (params["source_term"] || "") != ""
 
     changed? =
-      case socket.assigns[:entry] do
+      case socket.assigns[:term] do
         nil ->
           false
 
-        entry ->
-          params["source_term"] != entry.source_term or
-            (params["definition"] || "") != (entry.definition || "")
+        term ->
+          params["source_term"] != term.source_term or
+            (params["definition"] || "") != (term.definition || "")
       end
 
     {:noreply,
      assign(socket,
-       entry_form: to_form(params, as: :entry),
-       entry_form_valid?: valid?,
-       entry_edit_changed?: changed?
+       term_form: to_form(params, as: :term),
+       term_form_valid?: valid?,
+       term_edit_changed?: changed?
      )}
   end
 
-  def handle_event("create_kit_entry", %{"entry" => params}, socket) do
+  def handle_event("create_kit_term", %{"term" => params}, socket) do
     kit = socket.assigns.kit
     user = socket.assigns.current_user
     account = socket.assigns.account
@@ -2364,30 +2364,30 @@ defmodule GlossiaWeb.DashboardLive do
         |> Enum.map(fn {_idx, t} -> t end)
         |> Enum.reject(fn t -> (t["translated_term"] || "") == "" end)
 
-      entry_params = Map.put(params, "translations", translations)
+      term_params = Map.put(params, "translations", translations)
 
-      case Kits.add_entry(kit, entry_params) do
-        {:ok, _entry} ->
-          Auditing.record("kit_entry.created", account, user,
-            resource_type: "kit_entry",
+      case Kits.add_term(kit, term_params) do
+        {:ok, _term} ->
+          Auditing.record("kit_term.created", account, user,
+            resource_type: "kit_term",
             resource_id: to_string(kit.id),
             resource_path: "/#{socket.assigns.handle}/-/kits/#{kit.handle}",
-            summary: "Added entry \"#{params["source_term"]}\" to kit \"#{kit.name}\""
+            summary: "Added term \"#{params["source_term"]}\" to kit \"#{kit.name}\""
           )
 
           {:noreply,
            socket
-           |> put_flash(:info, gettext("Entry added."))
+           |> put_flash(:info, gettext("Term added."))
            |> push_patch(to: "/#{socket.assigns.handle}/-/kits/#{kit.handle}")}
 
         {:error, changeset} ->
-          {:noreply, assign(socket, entry_form: to_form(changeset, as: :entry))}
+          {:noreply, assign(socket, term_form: to_form(changeset, as: :term))}
       end
     end
   end
 
-  def handle_event("update_kit_entry", %{"entry" => params}, socket) do
-    entry = socket.assigns.entry
+  def handle_event("update_kit_term", %{"term" => params}, socket) do
+    term = socket.assigns.term
     kit = socket.assigns.kit
     user = socket.assigns.current_user
     account = socket.assigns.account
@@ -2400,29 +2400,29 @@ defmodule GlossiaWeb.DashboardLive do
         |> Enum.map(fn {_idx, t} -> t end)
         |> Enum.reject(fn t -> (t["translated_term"] || "") == "" end)
 
-      entry_params = Map.put(params, "translations", translations)
+      term_params = Map.put(params, "translations", translations)
 
-      case Kits.update_entry(entry, entry_params) do
-        {:ok, _updated_entry} ->
-          Auditing.record("kit_entry.updated", account, user,
-            resource_type: "kit_entry",
-            resource_id: to_string(entry.id),
+      case Kits.update_term(term, term_params) do
+        {:ok, _updated_term} ->
+          Auditing.record("kit_term.updated", account, user,
+            resource_type: "kit_term",
+            resource_id: to_string(term.id),
             resource_path: "/#{socket.assigns.handle}/-/kits/#{kit.handle}",
-            summary: "Updated entry \"#{params["source_term"]}\" in kit \"#{kit.name}\""
+            summary: "Updated term \"#{params["source_term"]}\" in kit \"#{kit.name}\""
           )
 
           {:noreply,
            socket
-           |> put_flash(:info, gettext("Entry updated."))
+           |> put_flash(:info, gettext("Term updated."))
            |> push_patch(to: "/#{socket.assigns.handle}/-/kits/#{kit.handle}")}
 
         {:error, changeset} ->
-          {:noreply, assign(socket, entry_form: to_form(changeset, as: :entry))}
+          {:noreply, assign(socket, term_form: to_form(changeset, as: :term))}
       end
     end
   end
 
-  def handle_event("delete_kit_entry", %{"entry-id" => entry_id}, socket) do
+  def handle_event("delete_kit_term", %{"term-id" => term_id}, socket) do
     kit = socket.assigns.kit
     user = socket.assigns.current_user
     account = socket.assigns.account
@@ -2430,15 +2430,15 @@ defmodule GlossiaWeb.DashboardLive do
     unless Glossia.Policy.authorize?(:kit_write, user, account) do
       {:noreply, put_flash(socket, :error, gettext("You don't have permission."))}
     else
-      entry = Kits.get_entry!(entry_id)
+      term = Kits.get_term!(term_id)
 
-      case Kits.delete_entry(entry) do
+      case Kits.delete_term(term) do
         {:ok, _} ->
-          Auditing.record("kit_entry.deleted", account, user,
-            resource_type: "kit_entry",
-            resource_id: to_string(entry.id),
+          Auditing.record("kit_term.deleted", account, user,
+            resource_type: "kit_term",
+            resource_id: to_string(term.id),
             resource_path: "/#{socket.assigns.handle}/-/kits/#{kit.handle}",
-            summary: "Deleted entry \"#{entry.source_term}\" from kit \"#{kit.name}\""
+            summary: "Deleted term \"#{term.source_term}\" from kit \"#{kit.name}\""
           )
 
           kit = Kits.get_kit!(kit.id)
@@ -2446,10 +2446,10 @@ defmodule GlossiaWeb.DashboardLive do
           {:noreply,
            socket
            |> assign(kit: kit)
-           |> put_flash(:info, gettext("Entry deleted."))}
+           |> put_flash(:info, gettext("Term deleted."))}
 
         {:error, _} ->
-          {:noreply, put_flash(socket, :error, gettext("Could not delete entry."))}
+          {:noreply, put_flash(socket, :error, gettext("Could not delete term."))}
       end
     end
   end
@@ -3351,7 +3351,7 @@ defmodule GlossiaWeb.DashboardLive do
           apps_sort_key={assigns[:apps_sort_key] || "inserted_at"}
           apps_sort_dir={assigns[:apps_sort_dir] || "desc"}
         />
-      <% action when action in [:kits, :kit_new, :kit_show, :kit_edit, :kit_entry_new, :kit_entry_edit] -> %>
+      <% action when action in [:kits, :kit_new, :kit_show, :kit_edit, :kit_term_new, :kit_term_edit] -> %>
         <.kits_page
           live_action={@live_action}
           handle={@handle}
@@ -3361,10 +3361,10 @@ defmodule GlossiaWeb.DashboardLive do
           kit_form_valid?={assigns[:kit_form_valid?] || false}
           kit_edit_changed?={assigns[:kit_edit_changed?] || false}
           kit_starred?={assigns[:kit_starred?] || false}
-          entry={assigns[:entry]}
-          entry_form={assigns[:entry_form]}
-          entry_form_valid?={assigns[:entry_form_valid?] || false}
-          entry_edit_changed?={assigns[:entry_edit_changed?] || false}
+          term={assigns[:term]}
+          term_form={assigns[:term_form]}
+          term_form_valid?={assigns[:term_form_valid?] || false}
+          term_edit_changed?={assigns[:term_edit_changed?] || false}
           kits_sort_key={assigns[:kits_sort_key] || "inserted_at"}
           kits_sort_dir={assigns[:kits_sort_dir] || "desc"}
           kits_active_filters={assigns[:kits_active_filters] || %{}}
@@ -10131,8 +10131,8 @@ defmodule GlossiaWeb.DashboardLive do
       :kit_new -> kit_new_page(assigns)
       :kit_show -> kit_show_page(assigns)
       :kit_edit -> kit_edit_page(assigns)
-      :kit_entry_new -> kit_entry_new_page(assigns)
-      :kit_entry_edit -> kit_entry_edit_page(assigns)
+      :kit_term_new -> kit_term_new_page(assigns)
+      :kit_term_edit -> kit_term_edit_page(assigns)
     end
   end
 
@@ -10302,10 +10302,10 @@ defmodule GlossiaWeb.DashboardLive do
               {gettext("Edit")}
             </.link>
             <.link
-              patch={"/" <> @handle <> "/-/kits/" <> @kit.handle <> "/entries/new"}
+              patch={"/" <> @handle <> "/-/kits/" <> @kit.handle <> "/terms/new"}
               class="dash-btn dash-btn-primary"
             >
-              {gettext("Add entry")}
+              {gettext("Add term")}
             </.link>
           <% end %>
         </:actions>
@@ -10325,8 +10325,8 @@ defmodule GlossiaWeb.DashboardLive do
         <% end %>
       </div>
 
-      <%= if @kit.entries != [] do %>
-        <table class="dash-table" id="kit-entries-table">
+      <%= if @kit.terms != [] do %>
+        <table class="dash-table" id="kit-terms-table">
           <thead>
             <tr>
               <th>{gettext("Term")}</th>
@@ -10338,23 +10338,23 @@ defmodule GlossiaWeb.DashboardLive do
             </tr>
           </thead>
           <tbody>
-            <%= for entry <- @kit.entries do %>
-              <tr id={"entry-#{entry.id}"}>
+            <%= for term <- @kit.terms do %>
+              <tr id={"term-#{term.id}"}>
                 <td>
                   <%= if @can_kit_write do %>
                     <.link
-                      patch={"/" <> @handle <> "/-/kits/" <> @kit.handle <> "/entries/" <> entry.id}
+                      patch={"/" <> @handle <> "/-/kits/" <> @kit.handle <> "/terms/" <> term.id}
                       class="resource-link"
                     >
-                      {entry.source_term}
+                      {term.source_term}
                     </.link>
                   <% else %>
-                    {entry.source_term}
+                    {term.source_term}
                   <% end %>
                 </td>
-                <td style="color: var(--color-text-muted);">{entry.definition || "-"}</td>
+                <td style="color: var(--color-text-muted);">{term.definition || "-"}</td>
                 <td>
-                  <%= for t <- entry.translations do %>
+                  <%= for t <- term.translations do %>
                     <span style="display: inline-block; margin-right: var(--space-2);">
                       <strong>{t.language}:</strong> {t.translated_term}
                     </span>
@@ -10363,9 +10363,9 @@ defmodule GlossiaWeb.DashboardLive do
                 <%= if @can_kit_write do %>
                   <td>
                     <button
-                      phx-click="delete_kit_entry"
-                      phx-value-entry-id={entry.id}
-                      data-confirm={gettext("Are you sure you want to delete this entry?")}
+                      phx-click="delete_kit_term"
+                      phx-value-term-id={term.id}
+                      data-confirm={gettext("Are you sure you want to delete this term?")}
                       class="dash-btn dash-btn-danger dash-btn-sm"
                     >
                       {gettext("Delete")}
@@ -10391,8 +10391,8 @@ defmodule GlossiaWeb.DashboardLive do
           >
             <path d="m7.5 4.27 9 5.15" /><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" /><path d="m3.3 7 8.7 5 8.7-5" /><path d="M12 22V12" />
           </svg>
-          <h2>{gettext("No entries yet")}</h2>
-          <p>{gettext("Add terminology entries to this kit.")}</p>
+          <h2>{gettext("No terms yet")}</h2>
+          <p>{gettext("Add terms to this kit.")}</p>
         </div>
       <% end %>
 
@@ -10451,31 +10451,31 @@ defmodule GlossiaWeb.DashboardLive do
     """
   end
 
-  defp kit_entry_new_page(assigns) do
+  defp kit_term_new_page(assigns) do
     ~H"""
     <div class="dash-page">
       <.form
-        for={@entry_form}
-        id="entry-form"
-        phx-change="entry_validate"
-        phx-submit="create_kit_entry"
+        for={@term_form}
+        id="term-form"
+        phx-change="term_validate"
+        phx-submit="create_kit_term"
       >
         <div class="dash-form-section">
-          <h2 class="dash-form-section-title">{gettext("New entry")}</h2>
+          <h2 class="dash-form-section-title">{gettext("New term")}</h2>
           <.input
-            field={@entry_form[:source_term]}
+            field={@term_form[:source_term]}
             type="text"
             label={gettext("Source term")}
             placeholder="e.g. diagnosis"
           />
-          <.input field={@entry_form[:definition]} type="textarea" label={gettext("Definition")} />
+          <.input field={@term_form[:definition]} type="textarea" label={gettext("Definition")} />
         </div>
 
         <div class="dash-form-section">
           <h2 class="dash-form-section-title">{gettext("Translations")}</h2>
           <%= for {t, idx} <- Enum.with_index(@kit.target_languages) do %>
             <div class="dash-form-grid" style="align-items: end;">
-              <input type="hidden" name={"entry[translations][#{idx}][language]"} value={t} />
+              <input type="hidden" name={"term[translations][#{idx}][language]"} value={t} />
               <div>
                 <label class="dash-label">{gettext("Language")}</label>
                 <input
@@ -10490,7 +10490,7 @@ defmodule GlossiaWeb.DashboardLive do
                 <label class="dash-label">{gettext("Translation")}</label>
                 <input
                   type="text"
-                  name={"entry[translations][#{idx}][translated_term]"}
+                  name={"term[translations][#{idx}][translated_term]"}
                   class="dash-input"
                 />
               </div>
@@ -10498,7 +10498,7 @@ defmodule GlossiaWeb.DashboardLive do
                 <label class="dash-label">{gettext("Usage note")}</label>
                 <input
                   type="text"
-                  name={"entry[translations][#{idx}][usage_note]"}
+                  name={"term[translations][#{idx}][usage_note]"}
                   class="dash-input"
                 />
               </div>
@@ -10507,8 +10507,8 @@ defmodule GlossiaWeb.DashboardLive do
         </div>
 
         <.form_save_bar
-          id="entry-save-bar"
-          visible={@entry_form_valid?}
+          id="term-save-bar"
+          visible={@term_form_valid?}
           cancel_path={"/" <> @handle <> "/-/kits/" <> @kit.handle}
         />
       </.form>
@@ -10516,26 +10516,26 @@ defmodule GlossiaWeb.DashboardLive do
     """
   end
 
-  defp kit_entry_edit_page(assigns) do
+  defp kit_term_edit_page(assigns) do
     assigns =
       assign(
         assigns,
         :translations_by_lang,
-        Map.new(assigns.entry.translations || [], fn t -> {t.language, t} end)
+        Map.new(assigns.term.translations || [], fn t -> {t.language, t} end)
       )
 
     ~H"""
     <div class="dash-page">
       <.form
-        for={@entry_form}
-        id="entry-edit-form"
-        phx-change="entry_validate"
-        phx-submit="update_kit_entry"
+        for={@term_form}
+        id="term-edit-form"
+        phx-change="term_validate"
+        phx-submit="update_kit_term"
       >
         <div class="dash-form-section">
-          <h2 class="dash-form-section-title">{gettext("Edit entry")}</h2>
-          <.input field={@entry_form[:source_term]} type="text" label={gettext("Source term")} />
-          <.input field={@entry_form[:definition]} type="textarea" label={gettext("Definition")} />
+          <h2 class="dash-form-section-title">{gettext("Edit term")}</h2>
+          <.input field={@term_form[:source_term]} type="text" label={gettext("Source term")} />
+          <.input field={@term_form[:definition]} type="textarea" label={gettext("Definition")} />
         </div>
 
         <div class="dash-form-section">
@@ -10543,7 +10543,7 @@ defmodule GlossiaWeb.DashboardLive do
           <%= for {lang, idx} <- Enum.with_index(@kit.target_languages) do %>
             <% t = Map.get(@translations_by_lang, lang) %>
             <div class="dash-form-grid" style="align-items: end;">
-              <input type="hidden" name={"entry[translations][#{idx}][language]"} value={lang} />
+              <input type="hidden" name={"term[translations][#{idx}][language]"} value={lang} />
               <div>
                 <label class="dash-label">{gettext("Language")}</label>
                 <input
@@ -10558,7 +10558,7 @@ defmodule GlossiaWeb.DashboardLive do
                 <label class="dash-label">{gettext("Translation")}</label>
                 <input
                   type="text"
-                  name={"entry[translations][#{idx}][translated_term]"}
+                  name={"term[translations][#{idx}][translated_term]"}
                   value={if(t, do: t.translated_term, else: "")}
                   class="dash-input"
                 />
@@ -10567,7 +10567,7 @@ defmodule GlossiaWeb.DashboardLive do
                 <label class="dash-label">{gettext("Usage note")}</label>
                 <input
                   type="text"
-                  name={"entry[translations][#{idx}][usage_note]"}
+                  name={"term[translations][#{idx}][usage_note]"}
                   value={if(t, do: t.usage_note || "", else: "")}
                   class="dash-input"
                 />
@@ -10577,8 +10577,8 @@ defmodule GlossiaWeb.DashboardLive do
         </div>
 
         <.form_save_bar
-          id="entry-edit-save-bar"
-          visible={@entry_form_valid? and @entry_edit_changed?}
+          id="term-edit-save-bar"
+          visible={@term_form_valid? and @term_edit_changed?}
           cancel_path={"/" <> @handle <> "/-/kits/" <> @kit.handle}
         />
       </.form>

--- a/app/lib/glossia_web/live/dashboard_live.ex
+++ b/app/lib/glossia_web/live/dashboard_live.ex
@@ -10,6 +10,7 @@ defmodule GlossiaWeb.DashboardLive do
   alias Glossia.ChangeSummary
   alias Glossia.DeveloperTokens
   alias Glossia.Glossaries
+  alias Glossia.Kits
   alias Glossia.Organizations
   alias Glossia.Discussions
   alias Glossia.Voices
@@ -39,6 +40,7 @@ defmodule GlossiaWeb.DashboardLive do
         :members -> apply_url_params_members(socket, params)
         :voice -> apply_url_params_voice(socket, params)
         :glossary -> apply_url_params_glossary(socket, params)
+        :kits -> apply_url_params_kits(socket, params)
         :project_activity -> apply_url_params_activity(socket, params)
         :project_translations -> apply_url_params_translations(socket, params)
         :project_new -> apply_url_params_project_new(socket, params)
@@ -59,6 +61,12 @@ defmodule GlossiaWeb.DashboardLive do
         _ -> {[], 0}
       end
 
+    public_kits =
+      case Kits.list_public_kits(account) do
+        {:ok, {kits, _meta}} -> kits
+        _ -> []
+      end
+
     assign(socket,
       page_title: socket.assigns.handle,
       projects: projects,
@@ -67,6 +75,7 @@ defmodule GlossiaWeb.DashboardLive do
       projects_sort_key: "name",
       projects_sort_dir: "asc",
       projects_page: 1,
+      public_kits: public_kits,
       breadcrumb_items: []
     )
   end
@@ -729,6 +738,202 @@ defmodule GlossiaWeb.DashboardLive do
     %{code: "hu", name: "Hungarian", native: "Magyar"},
     %{code: "ca", name: "Catalan", native: "Catala"}
   ]
+
+  defp apply_action(socket, :kits, _params) do
+    require_action!(socket, :kit_read)
+    account = socket.assigns.account
+    handle = socket.assigns.handle
+
+    {:ok, {kits, _meta}} = Kits.list_kits(account)
+
+    assign(socket,
+      page_title: gettext("Kits"),
+      kits: kits,
+      kits_sort_key: "inserted_at",
+      kits_sort_dir: "desc",
+      kits_active_filters: %{},
+      breadcrumb_items: [{gettext("Kits"), "/" <> handle <> "/-/kits"}]
+    )
+  end
+
+  defp apply_action(socket, :kit_new, _params) do
+    require_action!(socket, :kit_write)
+    handle = socket.assigns.handle
+
+    assign(socket,
+      page_title: gettext("New kit"),
+      kit_form:
+        to_form(
+          %{
+            "handle" => "",
+            "name" => "",
+            "description" => "",
+            "source_language" => "en",
+            "target_languages" => [],
+            "domain_tags" => [],
+            "visibility" => "public"
+          },
+          as: :kit
+        ),
+      kit_form_valid?: false,
+      breadcrumb_items: [
+        {gettext("Kits"), "/" <> handle <> "/-/kits"},
+        {gettext("New kit"), nil}
+      ]
+    )
+  end
+
+  defp apply_action(socket, :kit_show, %{"kit_handle" => kit_handle}) do
+    require_action!(socket, :kit_read)
+    account = socket.assigns.account
+    handle = socket.assigns.handle
+    user = socket.assigns.current_user
+
+    kit = Kits.get_kit_by_handle(account, kit_handle)
+
+    unless kit do
+      raise Ecto.NoResultsError, queryable: Glossia.Kits.Kit
+    end
+
+    starred? = if user, do: Kits.starred_by?(kit, user), else: false
+
+    assign(socket,
+      page_title: kit.name,
+      kit: kit,
+      kit_starred?: starred?,
+      breadcrumb_items: [
+        {gettext("Kits"), "/" <> handle <> "/-/kits"},
+        {kit.name, nil}
+      ]
+    )
+  end
+
+  defp apply_action(socket, :kit_edit, %{"kit_handle" => kit_handle}) do
+    require_action!(socket, :kit_write)
+    account = socket.assigns.account
+    handle = socket.assigns.handle
+
+    kit = Kits.get_kit_by_handle(account, kit_handle)
+
+    unless kit do
+      raise Ecto.NoResultsError, queryable: Glossia.Kits.Kit
+    end
+
+    assign(socket,
+      page_title: gettext("Edit %{name}", name: kit.name),
+      kit: kit,
+      kit_form:
+        to_form(
+          %{
+            "handle" => kit.handle,
+            "name" => kit.name,
+            "description" => kit.description || "",
+            "source_language" => kit.source_language,
+            "target_languages" => kit.target_languages,
+            "domain_tags" => kit.domain_tags,
+            "visibility" => kit.visibility
+          },
+          as: :kit
+        ),
+      kit_form_valid?: true,
+      kit_edit_changed?: false,
+      breadcrumb_items: [
+        {gettext("Kits"), "/" <> handle <> "/-/kits"},
+        {kit.name, "/" <> handle <> "/-/kits/" <> kit.handle},
+        {gettext("Edit"), nil}
+      ]
+    )
+  end
+
+  defp apply_action(socket, :kit_entry_new, %{"kit_handle" => kit_handle}) do
+    require_action!(socket, :kit_write)
+    account = socket.assigns.account
+    handle = socket.assigns.handle
+
+    kit = Kits.get_kit_by_handle(account, kit_handle)
+
+    unless kit do
+      raise Ecto.NoResultsError, queryable: Glossia.Kits.Kit
+    end
+
+    assign(socket,
+      page_title: gettext("New entry"),
+      kit: kit,
+      entry_form:
+        to_form(
+          %{
+            "source_term" => "",
+            "definition" => "",
+            "tags" => [],
+            "translations" =>
+              Enum.map(kit.target_languages, fn lang ->
+                %{"language" => lang, "translated_term" => "", "usage_note" => ""}
+              end)
+          },
+          as: :entry
+        ),
+      entry_form_valid?: false,
+      breadcrumb_items: [
+        {gettext("Kits"), "/" <> handle <> "/-/kits"},
+        {kit.name, "/" <> handle <> "/-/kits/" <> kit.handle},
+        {gettext("New entry"), nil}
+      ]
+    )
+  end
+
+  defp apply_action(socket, :kit_entry_edit, %{"kit_handle" => kit_handle, "entry_id" => entry_id}) do
+    require_action!(socket, :kit_write)
+    account = socket.assigns.account
+    handle = socket.assigns.handle
+
+    kit = Kits.get_kit_by_handle(account, kit_handle)
+
+    unless kit do
+      raise Ecto.NoResultsError, queryable: Glossia.Kits.Kit
+    end
+
+    entry = Kits.get_entry!(entry_id)
+
+    existing_translations =
+      Enum.map(entry.translations, fn t ->
+        %{
+          "language" => t.language,
+          "translated_term" => t.translated_term,
+          "usage_note" => t.usage_note || ""
+        }
+      end)
+
+    missing_langs = kit.target_languages -- Enum.map(entry.translations, & &1.language)
+
+    all_translations =
+      existing_translations ++
+        Enum.map(missing_langs, fn lang ->
+          %{"language" => lang, "translated_term" => "", "usage_note" => ""}
+        end)
+
+    assign(socket,
+      page_title: entry.source_term,
+      kit: kit,
+      entry: entry,
+      entry_form:
+        to_form(
+          %{
+            "source_term" => entry.source_term,
+            "definition" => entry.definition || "",
+            "tags" => entry.tags,
+            "translations" => all_translations
+          },
+          as: :entry
+        ),
+      entry_form_valid?: true,
+      entry_edit_changed?: false,
+      breadcrumb_items: [
+        {gettext("Kits"), "/" <> handle <> "/-/kits"},
+        {kit.name, "/" <> handle <> "/-/kits/" <> kit.handle},
+        {entry.source_term, nil}
+      ]
+    )
+  end
 
   defp apply_action(socket, :discussions, params) do
     account = socket.assigns.account
@@ -2012,6 +2217,272 @@ defmodule GlossiaWeb.DashboardLive do
   end
 
   # ---------------------------------------------------------------------------
+  # Kit events
+  # ---------------------------------------------------------------------------
+
+  def handle_event("kit_validate", %{"kit" => params}, socket) do
+    valid? =
+      (params["handle"] || "") != "" and
+        (params["name"] || "") != "" and
+        (params["source_language"] || "") != ""
+
+    changed? =
+      case socket.assigns[:kit] do
+        nil ->
+          false
+
+        kit ->
+          params["handle"] != kit.handle or
+            params["name"] != kit.name or
+            (params["description"] || "") != (kit.description || "") or
+            params["source_language"] != kit.source_language or
+            params["visibility"] != kit.visibility
+      end
+
+    {:noreply,
+     assign(socket,
+       kit_form: to_form(params, as: :kit),
+       kit_form_valid?: valid?,
+       kit_edit_changed?: changed?
+     )}
+  end
+
+  def handle_event("create_kit", %{"kit" => params}, socket) do
+    account = socket.assigns.account
+    user = socket.assigns.current_user
+
+    unless Glossia.Policy.authorize?(:kit_write, user, account) do
+      {:noreply, put_flash(socket, :error, gettext("You don't have permission."))}
+    else
+      case Kits.create_kit(account, user, params) do
+        {:ok, kit} ->
+          Auditing.record("kit.created", account, user,
+            resource_type: "kit",
+            resource_id: to_string(kit.id),
+            resource_path: "/#{socket.assigns.handle}/-/kits/#{kit.handle}",
+            summary: "Created kit \"#{kit.name}\""
+          )
+
+          {:noreply,
+           socket
+           |> put_flash(:info, gettext("Kit created."))
+           |> push_patch(to: "/#{socket.assigns.handle}/-/kits/#{kit.handle}")}
+
+        {:error, changeset} ->
+          {:noreply, assign(socket, kit_form: to_form(changeset, as: :kit))}
+      end
+    end
+  end
+
+  def handle_event("update_kit", %{"kit" => params}, socket) do
+    kit = socket.assigns.kit
+    user = socket.assigns.current_user
+    account = socket.assigns.account
+
+    unless Glossia.Policy.authorize?(:kit_write, user, account) do
+      {:noreply, put_flash(socket, :error, gettext("You don't have permission."))}
+    else
+      case Kits.update_kit(kit, params) do
+        {:ok, updated_kit} ->
+          Auditing.record("kit.updated", account, user,
+            resource_type: "kit",
+            resource_id: to_string(kit.id),
+            resource_path: "/#{socket.assigns.handle}/-/kits/#{updated_kit.handle}",
+            summary: "Updated kit \"#{updated_kit.name}\""
+          )
+
+          {:noreply,
+           socket
+           |> put_flash(:info, gettext("Kit updated."))
+           |> push_patch(to: "/#{socket.assigns.handle}/-/kits/#{updated_kit.handle}")}
+
+        {:error, changeset} ->
+          {:noreply, assign(socket, kit_form: to_form(changeset, as: :kit))}
+      end
+    end
+  end
+
+  def handle_event("delete_kit", _params, socket) do
+    kit = socket.assigns.kit
+    user = socket.assigns.current_user
+    account = socket.assigns.account
+
+    unless Glossia.Policy.authorize?(:kit_delete, user, account) do
+      {:noreply, put_flash(socket, :error, gettext("You don't have permission."))}
+    else
+      case Kits.delete_kit(kit) do
+        {:ok, _} ->
+          Auditing.record("kit.deleted", account, user,
+            resource_type: "kit",
+            resource_id: to_string(kit.id),
+            resource_path: "/#{socket.assigns.handle}/-/kits",
+            summary: "Deleted kit \"#{kit.name}\""
+          )
+
+          {:noreply,
+           socket
+           |> put_flash(:info, gettext("Kit deleted."))
+           |> push_patch(to: "/#{socket.assigns.handle}/-/kits")}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, gettext("Could not delete kit."))}
+      end
+    end
+  end
+
+  def handle_event("entry_validate", %{"entry" => params}, socket) do
+    valid? = (params["source_term"] || "") != ""
+
+    changed? =
+      case socket.assigns[:entry] do
+        nil ->
+          false
+
+        entry ->
+          params["source_term"] != entry.source_term or
+            (params["definition"] || "") != (entry.definition || "")
+      end
+
+    {:noreply,
+     assign(socket,
+       entry_form: to_form(params, as: :entry),
+       entry_form_valid?: valid?,
+       entry_edit_changed?: changed?
+     )}
+  end
+
+  def handle_event("create_kit_entry", %{"entry" => params}, socket) do
+    kit = socket.assigns.kit
+    user = socket.assigns.current_user
+    account = socket.assigns.account
+
+    unless Glossia.Policy.authorize?(:kit_write, user, account) do
+      {:noreply, put_flash(socket, :error, gettext("You don't have permission."))}
+    else
+      translations =
+        (params["translations"] || %{})
+        |> Enum.map(fn {_idx, t} -> t end)
+        |> Enum.reject(fn t -> (t["translated_term"] || "") == "" end)
+
+      entry_params = Map.put(params, "translations", translations)
+
+      case Kits.add_entry(kit, entry_params) do
+        {:ok, _entry} ->
+          Auditing.record("kit_entry.created", account, user,
+            resource_type: "kit_entry",
+            resource_id: to_string(kit.id),
+            resource_path: "/#{socket.assigns.handle}/-/kits/#{kit.handle}",
+            summary: "Added entry \"#{params["source_term"]}\" to kit \"#{kit.name}\""
+          )
+
+          {:noreply,
+           socket
+           |> put_flash(:info, gettext("Entry added."))
+           |> push_patch(to: "/#{socket.assigns.handle}/-/kits/#{kit.handle}")}
+
+        {:error, changeset} ->
+          {:noreply, assign(socket, entry_form: to_form(changeset, as: :entry))}
+      end
+    end
+  end
+
+  def handle_event("update_kit_entry", %{"entry" => params}, socket) do
+    entry = socket.assigns.entry
+    kit = socket.assigns.kit
+    user = socket.assigns.current_user
+    account = socket.assigns.account
+
+    unless Glossia.Policy.authorize?(:kit_write, user, account) do
+      {:noreply, put_flash(socket, :error, gettext("You don't have permission."))}
+    else
+      translations =
+        (params["translations"] || %{})
+        |> Enum.map(fn {_idx, t} -> t end)
+        |> Enum.reject(fn t -> (t["translated_term"] || "") == "" end)
+
+      entry_params = Map.put(params, "translations", translations)
+
+      case Kits.update_entry(entry, entry_params) do
+        {:ok, _updated_entry} ->
+          Auditing.record("kit_entry.updated", account, user,
+            resource_type: "kit_entry",
+            resource_id: to_string(entry.id),
+            resource_path: "/#{socket.assigns.handle}/-/kits/#{kit.handle}",
+            summary: "Updated entry \"#{params["source_term"]}\" in kit \"#{kit.name}\""
+          )
+
+          {:noreply,
+           socket
+           |> put_flash(:info, gettext("Entry updated."))
+           |> push_patch(to: "/#{socket.assigns.handle}/-/kits/#{kit.handle}")}
+
+        {:error, changeset} ->
+          {:noreply, assign(socket, entry_form: to_form(changeset, as: :entry))}
+      end
+    end
+  end
+
+  def handle_event("delete_kit_entry", %{"entry-id" => entry_id}, socket) do
+    kit = socket.assigns.kit
+    user = socket.assigns.current_user
+    account = socket.assigns.account
+
+    unless Glossia.Policy.authorize?(:kit_write, user, account) do
+      {:noreply, put_flash(socket, :error, gettext("You don't have permission."))}
+    else
+      entry = Kits.get_entry!(entry_id)
+
+      case Kits.delete_entry(entry) do
+        {:ok, _} ->
+          Auditing.record("kit_entry.deleted", account, user,
+            resource_type: "kit_entry",
+            resource_id: to_string(entry.id),
+            resource_path: "/#{socket.assigns.handle}/-/kits/#{kit.handle}",
+            summary: "Deleted entry \"#{entry.source_term}\" from kit \"#{kit.name}\""
+          )
+
+          kit = Kits.get_kit!(kit.id)
+
+          {:noreply,
+           socket
+           |> assign(kit: kit)
+           |> put_flash(:info, gettext("Entry deleted."))}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, gettext("Could not delete entry."))}
+      end
+    end
+  end
+
+  def handle_event("star_kit", _params, socket) do
+    kit = socket.assigns.kit
+    user = socket.assigns.current_user
+
+    case Kits.star_kit(kit, user) do
+      {:ok, _} ->
+        kit = Kits.get_kit!(kit.id)
+        {:noreply, assign(socket, kit: kit, kit_starred?: true)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, gettext("Could not star kit."))}
+    end
+  end
+
+  def handle_event("unstar_kit", _params, socket) do
+    kit = socket.assigns.kit
+    user = socket.assigns.current_user
+
+    case Kits.unstar_kit(kit, user) do
+      {:ok, _} ->
+        kit = Kits.get_kit!(kit.id)
+        {:noreply, assign(socket, kit: kit, kit_starred?: false)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, gettext("Could not unstar kit."))}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Ticket events
   # ---------------------------------------------------------------------------
 
@@ -2718,6 +3189,7 @@ defmodule GlossiaWeb.DashboardLive do
           projects_page={@projects_page}
           handle={@handle}
           can_write={@can_write}
+          public_kits={assigns[:public_kits] || []}
         />
       <% :logs -> %>
         <.logs_page
@@ -2878,6 +3350,26 @@ defmodule GlossiaWeb.DashboardLive do
           app_edit_changed?={assigns[:app_edit_changed?] || false}
           apps_sort_key={assigns[:apps_sort_key] || "inserted_at"}
           apps_sort_dir={assigns[:apps_sort_dir] || "desc"}
+        />
+      <% action when action in [:kits, :kit_new, :kit_show, :kit_edit, :kit_entry_new, :kit_entry_edit] -> %>
+        <.kits_page
+          live_action={@live_action}
+          handle={@handle}
+          kits={assigns[:kits] || []}
+          kit={assigns[:kit]}
+          kit_form={assigns[:kit_form]}
+          kit_form_valid?={assigns[:kit_form_valid?] || false}
+          kit_edit_changed?={assigns[:kit_edit_changed?] || false}
+          kit_starred?={assigns[:kit_starred?] || false}
+          entry={assigns[:entry]}
+          entry_form={assigns[:entry_form]}
+          entry_form_valid?={assigns[:entry_form_valid?] || false}
+          entry_edit_changed?={assigns[:entry_edit_changed?] || false}
+          kits_sort_key={assigns[:kits_sort_key] || "inserted_at"}
+          kits_sort_dir={assigns[:kits_sort_dir] || "desc"}
+          kits_active_filters={assigns[:kits_active_filters] || %{}}
+          current_user={@current_user}
+          can_kit_write={assigns[:can_kit_write] || false}
         />
       <% action when action in [:discussions, :discussion_new, :discussion_show] -> %>
         <.discussions_page
@@ -3048,6 +3540,34 @@ defmodule GlossiaWeb.DashboardLive do
           </div>
         </:empty>
       </.resource_table>
+
+      <%= if @public_kits != [] do %>
+        <div style="margin-top: var(--space-8);">
+          <h2 style="font-size: var(--text-lg); font-weight: var(--weight-semibold); margin-bottom: var(--space-4);">
+            {gettext("Kits")}
+          </h2>
+          <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-4);">
+            <%= for kit <- @public_kits do %>
+              <.link
+                navigate={"/" <> @handle <> "/-/kits/" <> kit.handle}
+                class="card"
+                style="text-decoration: none;"
+              >
+                <h3 style="font-weight: var(--weight-semibold); margin-bottom: var(--space-1);">
+                  {kit.name}
+                </h3>
+                <p style="color: var(--color-text-muted); font-size: var(--text-sm); margin-bottom: var(--space-2);">
+                  {kit.description || gettext("No description")}
+                </p>
+                <div style="display: flex; gap: var(--space-3); font-size: var(--text-xs); color: var(--color-text-muted);">
+                  <span>{kit.source_language} &rarr; {Enum.join(kit.target_languages, ", ")}</span>
+                  <span>&star; {kit.stars_count}</span>
+                </div>
+              </.link>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     </div>
     """
   end
@@ -8684,6 +9204,7 @@ defmodule GlossiaWeb.DashboardLive do
     "tokens-table" => "t",
     "oauth-apps-table" => "a",
     "discussions-table" => "k",
+    "kits-table" => "kt",
     "translations-table" => "ts",
     "commits-table" => "c"
   }
@@ -8716,6 +9237,7 @@ defmodule GlossiaWeb.DashboardLive do
         :members -> "/#{handle}/-/members"
         :api_tokens -> "/#{handle}/-/settings/tokens"
         :api_apps -> "/#{handle}/-/settings/apps"
+        :kits -> "/#{handle}/-/kits"
         :discussions -> "/#{handle}/-/discussions"
         :project_translations -> "/#{handle}/#{project_handle}/-/translations"
         :project_activity -> "/#{handle}/#{project_handle}/-/activity"
@@ -8922,6 +9444,14 @@ defmodule GlossiaWeb.DashboardLive do
     }
   end
 
+  defp current_table_state(socket, "kits-table") do
+    %{
+      sort: socket.assigns[:kits_sort_key] || "inserted_at",
+      dir: socket.assigns[:kits_sort_dir] || "desc",
+      filters: socket.assigns[:kits_active_filters] || %{}
+    }
+  end
+
   defp current_table_state(_socket, _id),
     do: %{search: "", sort: "", dir: "asc", page: 1, filters: %{}}
 
@@ -8932,11 +9462,13 @@ defmodule GlossiaWeb.DashboardLive do
   defp default_sort_key("invitations-table"), do: "email"
   defp default_sort_key("tokens-table"), do: "name"
   defp default_sort_key("oauth-apps-table"), do: "name"
+  defp default_sort_key("kits-table"), do: "inserted_at"
   defp default_sort_key("discussions-table"), do: "inserted_at"
   defp default_sort_key("translations-table"), do: "inserted_at"
   defp default_sort_key(_), do: ""
 
   defp default_sort_dir("activity-table"), do: "desc"
+  defp default_sort_dir("kits-table"), do: "desc"
   defp default_sort_dir("discussions-table"), do: "desc"
   defp default_sort_dir("translations-table"), do: "desc"
   defp default_sort_dir("commits-table"), do: "desc"
@@ -8956,6 +9488,10 @@ defmodule GlossiaWeb.DashboardLive do
 
   defp current_sort(socket, "oauth-apps-table"),
     do: {socket.assigns[:apps_sort_key] || "name", socket.assigns[:apps_sort_dir] || "asc"}
+
+  defp current_sort(socket, "kits-table"),
+    do:
+      {socket.assigns[:kits_sort_key] || "inserted_at", socket.assigns[:kits_sort_dir] || "desc"}
 
   defp current_sort(socket, "discussions-table"),
     do:
@@ -9165,6 +9701,29 @@ defmodule GlossiaWeb.DashboardLive do
       end
 
     assign(socket, projects: projects, projects_total: total)
+  end
+
+  defp apply_url_params_kits(socket, params) do
+    prefix = "kt"
+    sort_key = Map.get(params, prefix <> "sort", "inserted_at")
+    sort_dir = Map.get(params, prefix <> "dir", "desc")
+    active_filters = extract_filters(params, prefix)
+
+    flop_params =
+      %{
+        "order_by" => [sort_key],
+        "order_directions" => [sort_dir]
+      }
+      |> maybe_add_flop_filters(active_filters, %{})
+
+    {:ok, {kits, _meta}} = Kits.list_kits(socket.assigns.account, flop_params)
+
+    assign(socket,
+      kits: kits,
+      kits_sort_key: sort_key,
+      kits_sort_dir: sort_dir,
+      kits_active_filters: active_filters
+    )
   end
 
   defp apply_url_params_logs(socket, params) do
@@ -9560,6 +10119,471 @@ defmodule GlossiaWeb.DashboardLive do
 
     sorted = Enum.sort_by(invitations, sorter)
     if dir == "desc", do: Enum.reverse(sorted), else: sorted
+  end
+
+  # ---------------------------------------------------------------------------
+  # Page: Kits
+  # ---------------------------------------------------------------------------
+
+  defp kits_page(assigns) do
+    case assigns.live_action do
+      :kits -> kits_list_page(assigns)
+      :kit_new -> kit_new_page(assigns)
+      :kit_show -> kit_show_page(assigns)
+      :kit_edit -> kit_edit_page(assigns)
+      :kit_entry_new -> kit_entry_new_page(assigns)
+      :kit_entry_edit -> kit_entry_edit_page(assigns)
+    end
+  end
+
+  defp kits_list_page(assigns) do
+    ~H"""
+    <div class="dash-page">
+      <.page_header
+        title={gettext("Kits")}
+        description={gettext("Shareable translation terminology bundles.")}
+      >
+        <:actions>
+          <%= if @can_kit_write do %>
+            <.link patch={"/" <> @handle <> "/-/kits/new"} class="dash-btn dash-btn-primary">
+              {gettext("New kit")}
+            </.link>
+          <% end %>
+        </:actions>
+      </.page_header>
+      <.resource_table
+        id="kits-table"
+        rows={@kits}
+        sort_key={@kits_sort_key}
+        sort_dir={@kits_sort_dir}
+      >
+        <:col :let={kit} label={gettext("Name")} key="name" sortable>
+          <.link
+            patch={"/" <> @handle <> "/-/kits/" <> kit.handle}
+            class="resource-link"
+          >
+            {kit.name}
+          </.link>
+        </:col>
+        <:col :let={kit} label={gettext("Source")} key="source_language" sortable>
+          {kit.source_language}
+        </:col>
+        <:col :let={kit} label={gettext("Targets")}>
+          {Enum.join(kit.target_languages, ", ")}
+        </:col>
+        <:col :let={kit} label={gettext("Visibility")}>
+          <.badge variant={if kit.visibility == "public", do: "info", else: "default"}>
+            {kit.visibility}
+          </.badge>
+        </:col>
+        <:col :let={kit} label={gettext("Stars")} key="stars_count" sortable>
+          {kit.stars_count}
+        </:col>
+        <:col :let={kit} label={gettext("Created")} key="inserted_at" sortable>
+          {Calendar.strftime(kit.inserted_at, "%b %d, %Y")}
+        </:col>
+        <:empty>
+          <div class="dash-empty-state">
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="m7.5 4.27 9 5.15" /><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" /><path d="m3.3 7 8.7 5 8.7-5" /><path d="M12 22V12" />
+            </svg>
+            <h2>{gettext("No kits yet")}</h2>
+            <p>{gettext("Create a kit to bundle translation terminology for sharing.")}</p>
+          </div>
+        </:empty>
+      </.resource_table>
+    </div>
+    """
+  end
+
+  defp kit_new_page(assigns) do
+    ~H"""
+    <div class="dash-page">
+      <.form for={@kit_form} id="kit-form" phx-change="kit_validate" phx-submit="create_kit">
+        <div class="dash-form-section">
+          <h2 class="dash-form-section-title">{gettext("Kit details")}</h2>
+          <div class="dash-form-grid">
+            <.input
+              field={@kit_form[:handle]}
+              type="text"
+              label={gettext("Handle")}
+              placeholder="e.g. medical-terms"
+            />
+            <.input
+              field={@kit_form[:name]}
+              type="text"
+              label={gettext("Name")}
+              placeholder="e.g. Medical Terminology"
+            />
+          </div>
+          <.input field={@kit_form[:description]} type="textarea" label={gettext("Description")} />
+          <div class="dash-form-grid">
+            <.input
+              field={@kit_form[:source_language]}
+              type="text"
+              label={gettext("Source language")}
+              placeholder="e.g. en"
+            />
+            <.input
+              field={@kit_form[:visibility]}
+              type="select"
+              label={gettext("Visibility")}
+              options={[{gettext("Public"), "public"}, {gettext("Private"), "private"}]}
+            />
+          </div>
+        </div>
+        <.form_save_bar
+          id="kit-save-bar"
+          visible={@kit_form_valid?}
+          cancel_path={"/" <> @handle <> "/-/kits"}
+        />
+      </.form>
+    </div>
+    """
+  end
+
+  defp kit_show_page(assigns) do
+    ~H"""
+    <div class="dash-page">
+      <.page_header title={@kit.name} description={@kit.description}>
+        <:actions>
+          <%= if @current_user do %>
+            <%= if @kit_starred? do %>
+              <button phx-click="unstar_kit" class="dash-btn dash-btn-secondary">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                </svg>
+                <span>{@kit.stars_count}</span>
+              </button>
+            <% else %>
+              <button phx-click="star_kit" class="dash-btn dash-btn-secondary">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                </svg>
+                <span>{@kit.stars_count}</span>
+              </button>
+            <% end %>
+          <% end %>
+          <%= if @can_kit_write do %>
+            <.link
+              patch={"/" <> @handle <> "/-/kits/" <> @kit.handle <> "/edit"}
+              class="dash-btn dash-btn-secondary"
+            >
+              {gettext("Edit")}
+            </.link>
+            <.link
+              patch={"/" <> @handle <> "/-/kits/" <> @kit.handle <> "/entries/new"}
+              class="dash-btn dash-btn-primary"
+            >
+              {gettext("Add entry")}
+            </.link>
+          <% end %>
+        </:actions>
+      </.page_header>
+
+      <div
+        class="dash-metadata"
+        style="margin-bottom: var(--space-6); display: flex; gap: var(--space-4); flex-wrap: wrap;"
+      >
+        <.badge variant="info">{@kit.source_language}</.badge>
+        <span style="color: var(--color-text-muted);">&rarr;</span>
+        <%= for lang <- @kit.target_languages do %>
+          <.badge>{lang}</.badge>
+        <% end %>
+        <%= if @kit.visibility == "private" do %>
+          <.badge variant="warning">{gettext("Private")}</.badge>
+        <% end %>
+      </div>
+
+      <%= if @kit.entries != [] do %>
+        <table class="dash-table" id="kit-entries-table">
+          <thead>
+            <tr>
+              <th>{gettext("Term")}</th>
+              <th>{gettext("Definition")}</th>
+              <th>{gettext("Translations")}</th>
+              <%= if @can_kit_write do %>
+                <th style="width: 100px;">{gettext("Actions")}</th>
+              <% end %>
+            </tr>
+          </thead>
+          <tbody>
+            <%= for entry <- @kit.entries do %>
+              <tr id={"entry-#{entry.id}"}>
+                <td>
+                  <%= if @can_kit_write do %>
+                    <.link
+                      patch={"/" <> @handle <> "/-/kits/" <> @kit.handle <> "/entries/" <> entry.id}
+                      class="resource-link"
+                    >
+                      {entry.source_term}
+                    </.link>
+                  <% else %>
+                    {entry.source_term}
+                  <% end %>
+                </td>
+                <td style="color: var(--color-text-muted);">{entry.definition || "-"}</td>
+                <td>
+                  <%= for t <- entry.translations do %>
+                    <span style="display: inline-block; margin-right: var(--space-2);">
+                      <strong>{t.language}:</strong> {t.translated_term}
+                    </span>
+                  <% end %>
+                </td>
+                <%= if @can_kit_write do %>
+                  <td>
+                    <button
+                      phx-click="delete_kit_entry"
+                      phx-value-entry-id={entry.id}
+                      data-confirm={gettext("Are you sure you want to delete this entry?")}
+                      class="dash-btn dash-btn-danger dash-btn-sm"
+                    >
+                      {gettext("Delete")}
+                    </button>
+                  </td>
+                <% end %>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <div class="dash-empty-state">
+          <svg
+            width="32"
+            height="32"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="m7.5 4.27 9 5.15" /><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" /><path d="m3.3 7 8.7 5 8.7-5" /><path d="M12 22V12" />
+          </svg>
+          <h2>{gettext("No entries yet")}</h2>
+          <p>{gettext("Add terminology entries to this kit.")}</p>
+        </div>
+      <% end %>
+
+      <%= if @can_kit_write do %>
+        <div style="margin-top: var(--space-8); padding-top: var(--space-6); border-top: 1px solid var(--color-border);">
+          <h3 style="color: var(--color-danger); margin-bottom: var(--space-4);">
+            {gettext("Danger zone")}
+          </h3>
+          <button
+            phx-click="delete_kit"
+            data-confirm={
+              gettext("Are you sure you want to delete this kit? This action cannot be undone.")
+            }
+            class="dash-btn dash-btn-danger"
+          >
+            {gettext("Delete kit")}
+          </button>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  defp kit_edit_page(assigns) do
+    ~H"""
+    <div class="dash-page">
+      <.form for={@kit_form} id="kit-edit-form" phx-change="kit_validate" phx-submit="update_kit">
+        <div class="dash-form-section">
+          <h2 class="dash-form-section-title">{gettext("Edit kit")}</h2>
+          <div class="dash-form-grid">
+            <.input field={@kit_form[:handle]} type="text" label={gettext("Handle")} />
+            <.input field={@kit_form[:name]} type="text" label={gettext("Name")} />
+          </div>
+          <.input field={@kit_form[:description]} type="textarea" label={gettext("Description")} />
+          <div class="dash-form-grid">
+            <.input
+              field={@kit_form[:source_language]}
+              type="text"
+              label={gettext("Source language")}
+            />
+            <.input
+              field={@kit_form[:visibility]}
+              type="select"
+              label={gettext("Visibility")}
+              options={[{gettext("Public"), "public"}, {gettext("Private"), "private"}]}
+            />
+          </div>
+        </div>
+        <.form_save_bar
+          id="kit-edit-save-bar"
+          visible={@kit_form_valid? and @kit_edit_changed?}
+          cancel_path={"/" <> @handle <> "/-/kits/" <> @kit.handle}
+        />
+      </.form>
+    </div>
+    """
+  end
+
+  defp kit_entry_new_page(assigns) do
+    ~H"""
+    <div class="dash-page">
+      <.form
+        for={@entry_form}
+        id="entry-form"
+        phx-change="entry_validate"
+        phx-submit="create_kit_entry"
+      >
+        <div class="dash-form-section">
+          <h2 class="dash-form-section-title">{gettext("New entry")}</h2>
+          <.input
+            field={@entry_form[:source_term]}
+            type="text"
+            label={gettext("Source term")}
+            placeholder="e.g. diagnosis"
+          />
+          <.input field={@entry_form[:definition]} type="textarea" label={gettext("Definition")} />
+        </div>
+
+        <div class="dash-form-section">
+          <h2 class="dash-form-section-title">{gettext("Translations")}</h2>
+          <%= for {t, idx} <- Enum.with_index(@kit.target_languages) do %>
+            <div class="dash-form-grid" style="align-items: end;">
+              <input type="hidden" name={"entry[translations][#{idx}][language]"} value={t} />
+              <div>
+                <label class="dash-label">{gettext("Language")}</label>
+                <input
+                  type="text"
+                  value={t}
+                  disabled
+                  class="dash-input"
+                  style="opacity: 0.6; cursor: not-allowed;"
+                />
+              </div>
+              <div>
+                <label class="dash-label">{gettext("Translation")}</label>
+                <input
+                  type="text"
+                  name={"entry[translations][#{idx}][translated_term]"}
+                  class="dash-input"
+                />
+              </div>
+              <div>
+                <label class="dash-label">{gettext("Usage note")}</label>
+                <input
+                  type="text"
+                  name={"entry[translations][#{idx}][usage_note]"}
+                  class="dash-input"
+                />
+              </div>
+            </div>
+          <% end %>
+        </div>
+
+        <.form_save_bar
+          id="entry-save-bar"
+          visible={@entry_form_valid?}
+          cancel_path={"/" <> @handle <> "/-/kits/" <> @kit.handle}
+        />
+      </.form>
+    </div>
+    """
+  end
+
+  defp kit_entry_edit_page(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :translations_by_lang,
+        Map.new(assigns.entry.translations || [], fn t -> {t.language, t} end)
+      )
+
+    ~H"""
+    <div class="dash-page">
+      <.form
+        for={@entry_form}
+        id="entry-edit-form"
+        phx-change="entry_validate"
+        phx-submit="update_kit_entry"
+      >
+        <div class="dash-form-section">
+          <h2 class="dash-form-section-title">{gettext("Edit entry")}</h2>
+          <.input field={@entry_form[:source_term]} type="text" label={gettext("Source term")} />
+          <.input field={@entry_form[:definition]} type="textarea" label={gettext("Definition")} />
+        </div>
+
+        <div class="dash-form-section">
+          <h2 class="dash-form-section-title">{gettext("Translations")}</h2>
+          <%= for {lang, idx} <- Enum.with_index(@kit.target_languages) do %>
+            <% t = Map.get(@translations_by_lang, lang) %>
+            <div class="dash-form-grid" style="align-items: end;">
+              <input type="hidden" name={"entry[translations][#{idx}][language]"} value={lang} />
+              <div>
+                <label class="dash-label">{gettext("Language")}</label>
+                <input
+                  type="text"
+                  value={lang}
+                  disabled
+                  class="dash-input"
+                  style="opacity: 0.6; cursor: not-allowed;"
+                />
+              </div>
+              <div>
+                <label class="dash-label">{gettext("Translation")}</label>
+                <input
+                  type="text"
+                  name={"entry[translations][#{idx}][translated_term]"}
+                  value={if(t, do: t.translated_term, else: "")}
+                  class="dash-input"
+                />
+              </div>
+              <div>
+                <label class="dash-label">{gettext("Usage note")}</label>
+                <input
+                  type="text"
+                  name={"entry[translations][#{idx}][usage_note]"}
+                  value={if(t, do: t.usage_note || "", else: "")}
+                  class="dash-input"
+                />
+              </div>
+            </div>
+          <% end %>
+        </div>
+
+        <.form_save_bar
+          id="entry-edit-save-bar"
+          visible={@entry_form_valid? and @entry_edit_changed?}
+          cancel_path={"/" <> @handle <> "/-/kits/" <> @kit.handle}
+        />
+      </.form>
+    </div>
+    """
   end
 
   # ---------------------------------------------------------------------------

--- a/app/lib/glossia_web/live/platform_hooks.ex
+++ b/app/lib/glossia_web/live/platform_hooks.ex
@@ -88,6 +88,8 @@ defmodule GlossiaWeb.PlatformHooks do
 
     can_voice_propose = can_discussion_write
     can_glossary_propose = can_discussion_write
+    can_kit_read = Glossia.Policy.authorize?(:kit_read, user, account)
+    can_kit_write = Glossia.Policy.authorize?(:kit_write, user, account)
 
     show_sidebar = user != nil
 
@@ -101,6 +103,8 @@ defmodule GlossiaWeb.PlatformHooks do
      |> assign(:can_glossary_read, can_glossary_read)
      |> assign(:can_glossary_write, can_glossary_write)
      |> assign(:can_glossary_propose, can_glossary_propose)
+     |> assign(:can_kit_read, can_kit_read)
+     |> assign(:can_kit_write, can_kit_write)
      |> assign(:show_sidebar, show_sidebar)
      |> assign(:sidebar_context, :account)
      |> assign(:sidebar_project, nil)}

--- a/app/lib/glossia_web/router.ex
+++ b/app/lib/glossia_web/router.ex
@@ -279,7 +279,7 @@ defmodule GlossiaWeb.Router do
     get "/:handle/kits", KitApiController, :index
     get "/:handle/kits/:kit_handle", KitApiController, :show
     post "/:handle/kits", KitApiController, :create
-    post "/:handle/kits/:kit_handle/entries", KitApiController, :create_entry
+    post "/:handle/kits/:kit_handle/terms", KitApiController, :create_term
   end
 
   # MCP server (StreamableHTTP transport)
@@ -411,8 +411,8 @@ defmodule GlossiaWeb.Router do
       live "/:handle/-/kits/new", DashboardLive, :kit_new
       live "/:handle/-/kits/:kit_handle", DashboardLive, :kit_show
       live "/:handle/-/kits/:kit_handle/edit", DashboardLive, :kit_edit
-      live "/:handle/-/kits/:kit_handle/entries/new", DashboardLive, :kit_entry_new
-      live "/:handle/-/kits/:kit_handle/entries/:entry_id", DashboardLive, :kit_entry_edit
+      live "/:handle/-/kits/:kit_handle/terms/new", DashboardLive, :kit_term_new
+      live "/:handle/-/kits/:kit_handle/terms/:term_id", DashboardLive, :kit_term_edit
       live "/:handle/-/discussions", DashboardLive, :discussions
       live "/:handle/-/discussions/new", DashboardLive, :discussion_new
       live "/:handle/-/discussions/:discussion_number", DashboardLive, :discussion_show

--- a/app/lib/glossia_web/router.ex
+++ b/app/lib/glossia_web/router.ex
@@ -276,6 +276,10 @@ defmodule GlossiaWeb.Router do
     get "/:handle/glossary", GlossaryApiController, :show
     post "/:handle/glossary", GlossaryApiController, :create
     get "/:handle/glossary/history", GlossaryApiController, :history
+    get "/:handle/kits", KitApiController, :index
+    get "/:handle/kits/:kit_handle", KitApiController, :show
+    post "/:handle/kits", KitApiController, :create
+    post "/:handle/kits/:kit_handle/entries", KitApiController, :create_entry
   end
 
   # MCP server (StreamableHTTP transport)
@@ -403,6 +407,12 @@ defmodule GlossiaWeb.Router do
       live "/:handle/-/glossary/suggestion/new", DashboardLive, :glossary_suggestion_new
       live "/:handle/-/glossary/request/new", DashboardLive, :glossary_suggestion_new
       live "/:handle/-/glossary/:version", DashboardLive, :glossary_version
+      live "/:handle/-/kits", DashboardLive, :kits
+      live "/:handle/-/kits/new", DashboardLive, :kit_new
+      live "/:handle/-/kits/:kit_handle", DashboardLive, :kit_show
+      live "/:handle/-/kits/:kit_handle/edit", DashboardLive, :kit_edit
+      live "/:handle/-/kits/:kit_handle/entries/new", DashboardLive, :kit_entry_new
+      live "/:handle/-/kits/:kit_handle/entries/:entry_id", DashboardLive, :kit_entry_edit
       live "/:handle/-/discussions", DashboardLive, :discussions
       live "/:handle/-/discussions/new", DashboardLive, :discussion_new
       live "/:handle/-/discussions/:discussion_number", DashboardLive, :discussion_show

--- a/app/priv/changelog/2026-03-01-kits.md
+++ b/app/priv/changelog/2026-03-01-kits.md
@@ -1,0 +1,13 @@
+%{
+  title: "Kits: shareable translation terminology bundles",
+  summary: "Create, curate, and share themed bundles of translation terminology with per-language translations. Star kits from other accounts to build your linguist profile."
+}
+---
+
+We added **Kits** to Glossia. A kit is a themed bundle of translation terminology entries, each with per-language translations, that linguists can create, curate, and share publicly.
+
+Kits live under each account's dashboard with full CRUD support: create a kit, add entries with definitions and translations for each target language, and mark kits as public or private. Other users can star public kits to save them for later reference.
+
+Public kits also appear on account profile pages, making it easy to discover terminology bundles shared by other linguists and organizations.
+
+The same functionality is available through the REST API (`GET/POST /api/:handle/kits`) and MCP tools (`list_kits`, `get_kit`), so you can integrate kit management into your workflow regardless of the interface you prefer.

--- a/app/priv/gettext/default.pot
+++ b/app/priv/gettext/default.pot
@@ -28,6 +28,7 @@ msgstr ""
 
 #: lib/glossia_web/components/core_components.ex:393
 #: lib/glossia_web/components/dashboard_components.ex:258
+#: lib/glossia_web/live/dashboard_live.ex:10336
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -97,18 +98,18 @@ msgid "Cookie Policy"
 msgstr ""
 
 #: lib/glossia_web/controllers/legal_html/show.html.heex:33
-#: lib/glossia_web/live/dashboard_live.ex:3875
+#: lib/glossia_web/live/dashboard_live.ex:4395
 #, elixir-autogen, elixir-format
 msgid "Current"
 msgstr ""
 
 #: lib/glossia_web/controllers/legal_html/show.html.heex:21
-#: lib/glossia_web/live/dashboard_live.ex:3122
-#: lib/glossia_web/live/dashboard_live.ex:3643
-#: lib/glossia_web/live/dashboard_live.ex:3707
-#: lib/glossia_web/live/dashboard_live.ex:4275
-#: lib/glossia_web/live/dashboard_live.ex:4339
-#: lib/glossia_web/live/dashboard_live.ex:5763
+#: lib/glossia_web/live/dashboard_live.ex:3642
+#: lib/glossia_web/live/dashboard_live.ex:4163
+#: lib/glossia_web/live/dashboard_live.ex:4227
+#: lib/glossia_web/live/dashboard_live.ex:4795
+#: lib/glossia_web/live/dashboard_live.ex:4859
+#: lib/glossia_web/live/dashboard_live.ex:6283
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
@@ -147,8 +148,8 @@ msgstr ""
 #: lib/glossia_web/controllers/waitlist_html/form.html.heex:17
 #: lib/glossia_web/controllers/waitlist_html/submitted.html.heex:13
 #: lib/glossia_web/live/admin_live.ex:362
-#: lib/glossia_web/live/dashboard_live.ex:4586
-#: lib/glossia_web/live/dashboard_live.ex:4632
+#: lib/glossia_web/live/dashboard_live.ex:5106
+#: lib/glossia_web/live/dashboard_live.ex:5152
 #: lib/glossia_web/live/profile_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Email"
@@ -170,9 +171,11 @@ msgid "Get in touch"
 msgstr ""
 
 #: lib/glossia_web/components/layouts/app.html.heex:154
-#: lib/glossia_web/live/dashboard_live.ex:3545
-#: lib/glossia_web/live/dashboard_live.ex:6578
-#: lib/glossia_web/live/dashboard_live.ex:6793
+#: lib/glossia_web/live/dashboard_live.ex:4065
+#: lib/glossia_web/live/dashboard_live.ex:7098
+#: lib/glossia_web/live/dashboard_live.ex:7313
+#: lib/glossia_web/live/dashboard_live.ex:10480
+#: lib/glossia_web/live/dashboard_live.ex:10548
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -200,17 +203,17 @@ msgstr ""
 msgid "Motivation"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:635
-#: lib/glossia_web/live/dashboard_live.ex:638
-#: lib/glossia_web/live/dashboard_live.ex:672
-#: lib/glossia_web/live/dashboard_live.ex:683
-#: lib/glossia_web/live/dashboard_live.ex:2979
-#: lib/glossia_web/live/dashboard_live.ex:6469
+#: lib/glossia_web/live/dashboard_live.ex:644
+#: lib/glossia_web/live/dashboard_live.ex:647
+#: lib/glossia_web/live/dashboard_live.ex:681
+#: lib/glossia_web/live/dashboard_live.ex:692
+#: lib/glossia_web/live/dashboard_live.ex:3471
+#: lib/glossia_web/live/dashboard_live.ex:6989
 #, elixir-autogen, elixir-format
 msgid "New project"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3046
+#: lib/glossia_web/live/dashboard_live.ex:3538
 #, elixir-autogen, elixir-format
 msgid "No projects yet"
 msgstr ""
@@ -232,7 +235,7 @@ msgstr ""
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5513
+#: lib/glossia_web/live/dashboard_live.ex:6033
 #, elixir-autogen, elixir-format
 msgid "Project overview"
 msgstr ""
@@ -242,7 +245,7 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3047
+#: lib/glossia_web/live/dashboard_live.ex:3539
 #, elixir-autogen, elixir-format
 msgid "Projects will show up here once you create one."
 msgstr ""
@@ -321,14 +324,14 @@ msgstr ""
 msgid "There was a problem creating your account. Please try again."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5526
+#: lib/glossia_web/live/dashboard_live.ex:6046
 #, elixir-autogen, elixir-format
 msgid "This is a placeholder for the project detail page."
 msgstr ""
 
 #: lib/glossia_web/controllers/waitlist_html/form.html.heex:39
 #: lib/glossia_web/controllers/waitlist_html/submitted.html.heex:22
-#: lib/glossia_web/live/dashboard_live.ex:5667
+#: lib/glossia_web/live/dashboard_live.ex:6187
 #, elixir-autogen, elixir-format
 msgid "URL"
 msgstr ""
@@ -339,8 +342,8 @@ msgid "Version History"
 msgstr ""
 
 #: lib/glossia_web/controllers/legal_html/show.html.heex:35
-#: lib/glossia_web/live/dashboard_live.ex:5857
-#: lib/glossia_web/live/dashboard_live.ex:9663
+#: lib/glossia_web/live/dashboard_live.ex:6377
+#: lib/glossia_web/live/dashboard_live.ex:10687
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -396,7 +399,7 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4176
+#: lib/glossia_web/live/dashboard_live.ex:4696
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
@@ -468,14 +471,14 @@ msgstr ""
 msgid "You're subscribed. Welcome aboard."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3619
+#: lib/glossia_web/live/dashboard_live.ex:4139
 #, elixir-autogen, elixir-format
 msgid "Add language override"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3926
-#: lib/glossia_web/live/dashboard_live.ex:4454
-#: lib/glossia_web/live/dashboard_live.ex:7624
+#: lib/glossia_web/live/dashboard_live.ex:4446
+#: lib/glossia_web/live/dashboard_live.ex:4974
+#: lib/glossia_web/live/dashboard_live.ex:8144
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -501,12 +504,12 @@ msgstr ""
 msgid "Create organization"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3511
+#: lib/glossia_web/live/dashboard_live.ex:4031
 #, elixir-autogen, elixir-format
 msgid "Customize the voice for specific languages. Fields left empty will fall back to the base voice above."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3479
+#: lib/glossia_web/live/dashboard_live.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Detailed writing rules, brand voice notes, and things to avoid. Supports Markdown."
 msgstr ""
@@ -516,38 +519,40 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3425
-#: lib/glossia_web/live/dashboard_live.ex:3570
-#: lib/glossia_web/live/dashboard_live.ex:3838
-#: lib/glossia_web/live/dashboard_live.ex:3943
-#: lib/glossia_web/live/dashboard_live.ex:7103
+#: lib/glossia_web/live/dashboard_live.ex:3945
+#: lib/glossia_web/live/dashboard_live.ex:4090
+#: lib/glossia_web/live/dashboard_live.ex:4358
+#: lib/glossia_web/live/dashboard_live.ex:4463
+#: lib/glossia_web/live/dashboard_live.ex:7623
 #, elixir-autogen, elixir-format
 msgid "Formality"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3477
-#: lib/glossia_web/live/dashboard_live.ex:3592
-#: lib/glossia_web/live/dashboard_live.ex:3857
-#: lib/glossia_web/live/dashboard_live.ex:7117
+#: lib/glossia_web/live/dashboard_live.ex:3997
+#: lib/glossia_web/live/dashboard_live.ex:4112
+#: lib/glossia_web/live/dashboard_live.ex:4377
+#: lib/glossia_web/live/dashboard_live.ex:7637
 #, elixir-autogen, elixir-format
 msgid "Guidelines"
 msgstr ""
 
 #: lib/glossia_web/controllers/organization_html/new.html.heex:15
 #: lib/glossia_web/live/admin_live.ex:483
-#: lib/glossia_web/live/dashboard_live.ex:3001
+#: lib/glossia_web/live/dashboard_live.ex:3493
+#: lib/glossia_web/live/dashboard_live.ex:10219
+#: lib/glossia_web/live/dashboard_live.ex:10426
 #, elixir-autogen, elixir-format
 msgid "Handle"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3446
+#: lib/glossia_web/live/dashboard_live.ex:3966
 #, elixir-autogen, elixir-format
 msgid "How casual or formal the language should be."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3509
-#: lib/glossia_web/live/dashboard_live.ex:3895
-#: lib/glossia_web/live/dashboard_live.ex:7137
+#: lib/glossia_web/live/dashboard_live.ex:4029
+#: lib/glossia_web/live/dashboard_live.ex:4415
+#: lib/glossia_web/live/dashboard_live.ex:7657
 #, elixir-autogen, elixir-format
 msgid "Language overrides"
 msgstr ""
@@ -579,12 +584,12 @@ msgstr ""
 msgid "New organization"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3883
+#: lib/glossia_web/live/dashboard_live.ex:4403
 #, elixir-autogen, elixir-format
 msgid "No guidelines set."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4274
+#: lib/glossia_web/live/dashboard_live.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr ""
@@ -599,7 +604,7 @@ msgstr ""
 msgid "Organizations let you collaborate with your team on content projects."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3896
+#: lib/glossia_web/live/dashboard_live.ex:4416
 #, elixir-autogen, elixir-format
 msgid "Per-language voice customizations in this version."
 msgstr ""
@@ -609,28 +614,28 @@ msgstr ""
 msgid "Personal"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3867
+#: lib/glossia_web/live/dashboard_live.ex:4387
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3632
+#: lib/glossia_web/live/dashboard_live.ex:4152
 #, elixir-autogen, elixir-format
 msgid "Previous versions of your voice configuration."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3538
-#: lib/glossia_web/live/dashboard_live.ex:4086
-#: lib/glossia_web/live/dashboard_live.ex:4225
-#: lib/glossia_web/live/dashboard_live.ex:4614
-#: lib/glossia_web/live/dashboard_live.ex:5575
+#: lib/glossia_web/live/dashboard_live.ex:4058
+#: lib/glossia_web/live/dashboard_live.ex:4606
+#: lib/glossia_web/live/dashboard_live.ex:4745
+#: lib/glossia_web/live/dashboard_live.ex:5134
+#: lib/glossia_web/live/dashboard_live.ex:6095
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3930
-#: lib/glossia_web/live/dashboard_live.ex:4457
-#: lib/glossia_web/live/dashboard_live.ex:7625
+#: lib/glossia_web/live/dashboard_live.ex:4450
+#: lib/glossia_web/live/dashboard_live.ex:4977
+#: lib/glossia_web/live/dashboard_live.ex:8145
 #, elixir-autogen, elixir-format
 msgid "Removed"
 msgstr ""
@@ -641,17 +646,17 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3432
+#: lib/glossia_web/live/dashboard_live.ex:3952
 #, elixir-autogen, elixir-format
 msgid "Select a level"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3404
+#: lib/glossia_web/live/dashboard_live.ex:3924
 #, elixir-autogen, elixir-format
 msgid "Select a tone"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3388
+#: lib/glossia_web/live/dashboard_live.ex:3908
 #, elixir-autogen, elixir-format
 msgid "Set the overall personality and formality level for your content."
 msgstr ""
@@ -661,30 +666,30 @@ msgstr ""
 msgid "Subscribe to unlock %{handle}."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3454
-#: lib/glossia_web/live/dashboard_live.ex:3582
-#: lib/glossia_web/live/dashboard_live.ex:3845
-#: lib/glossia_web/live/dashboard_live.ex:7110
+#: lib/glossia_web/live/dashboard_live.ex:3974
+#: lib/glossia_web/live/dashboard_live.ex:4102
+#: lib/glossia_web/live/dashboard_live.ex:4365
+#: lib/glossia_web/live/dashboard_live.ex:7630
 #, elixir-autogen, elixir-format
 msgid "Target audience"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3417
+#: lib/glossia_web/live/dashboard_live.ex:3937
 #, elixir-autogen, elixir-format
 msgid "The general character of your writing."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3397
-#: lib/glossia_web/live/dashboard_live.ex:3559
-#: lib/glossia_web/live/dashboard_live.ex:3833
-#: lib/glossia_web/live/dashboard_live.ex:3938
-#: lib/glossia_web/live/dashboard_live.ex:7096
+#: lib/glossia_web/live/dashboard_live.ex:3917
+#: lib/glossia_web/live/dashboard_live.ex:4079
+#: lib/glossia_web/live/dashboard_live.ex:4353
+#: lib/glossia_web/live/dashboard_live.ex:4458
+#: lib/glossia_web/live/dashboard_live.ex:7616
 #, elixir-autogen, elixir-format
 msgid "Tone"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3387
-#: lib/glossia_web/live/dashboard_live.ex:3826
+#: lib/glossia_web/live/dashboard_live.ex:3907
+#: lib/glossia_web/live/dashboard_live.ex:4346
 #, elixir-autogen, elixir-format
 msgid "Tone and style"
 msgstr ""
@@ -694,29 +699,29 @@ msgstr ""
 msgid "Unsaved changes"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3561
-#: lib/glossia_web/live/dashboard_live.ex:3572
+#: lib/glossia_web/live/dashboard_live.ex:4081
+#: lib/glossia_web/live/dashboard_live.ex:4092
 #, elixir-autogen, elixir-format
 msgid "Use base"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3631
-#: lib/glossia_web/live/dashboard_live.ex:4262
+#: lib/glossia_web/live/dashboard_live.ex:4151
+#: lib/glossia_web/live/dashboard_live.ex:4782
 #, elixir-autogen, elixir-format
 msgid "Version history"
 msgstr ""
 
 #: lib/glossia_web/components/layouts/platform.html.heex:221
-#: lib/glossia_web/live/dashboard_live.ex:125
-#: lib/glossia_web/live/dashboard_live.ex:154
-#: lib/glossia_web/live/dashboard_live.ex:241
-#: lib/glossia_web/live/dashboard_live.ex:266
-#: lib/glossia_web/live/dashboard_live.ex:3195
+#: lib/glossia_web/live/dashboard_live.ex:134
+#: lib/glossia_web/live/dashboard_live.ex:163
+#: lib/glossia_web/live/dashboard_live.ex:250
+#: lib/glossia_web/live/dashboard_live.ex:275
+#: lib/glossia_web/live/dashboard_live.ex:3715
 #, elixir-autogen, elixir-format
 msgid "Voice"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3827
+#: lib/glossia_web/live/dashboard_live.ex:4347
 #, elixir-autogen, elixir-format
 msgid "Voice personality and formality settings for this version."
 msgstr ""
@@ -729,22 +734,22 @@ msgstr ""
 msgid "Waitlist"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3467
+#: lib/glossia_web/live/dashboard_live.ex:3987
 #, elixir-autogen, elixir-format
 msgid "Who you are writing for."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3496
+#: lib/glossia_web/live/dashboard_live.ex:4016
 #, elixir-autogen, elixir-format
 msgid "Write your brand voice guidelines here..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3491
+#: lib/glossia_web/live/dashboard_live.ex:4011
 #, elixir-autogen, elixir-format
 msgid "Writing guidelines"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3858
+#: lib/glossia_web/live/dashboard_live.ex:4378
 #, elixir-autogen, elixir-format
 msgid "Writing rules and brand voice notes."
 msgstr ""
@@ -754,7 +759,7 @@ msgstr ""
 msgid "Your subscription is active for %{handle}."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3463
+#: lib/glossia_web/live/dashboard_live.ex:3983
 #, elixir-autogen, elixir-format
 msgid "e.g. Developers, marketing teams, general public"
 msgstr ""
@@ -764,21 +769,21 @@ msgstr ""
 msgid "my-org"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3100
-#: lib/glossia_web/live/dashboard_live.ex:3648
-#: lib/glossia_web/live/dashboard_live.ex:3689
-#: lib/glossia_web/live/dashboard_live.ex:4280
-#: lib/glossia_web/live/dashboard_live.ex:4321
+#: lib/glossia_web/live/dashboard_live.ex:3620
+#: lib/glossia_web/live/dashboard_live.ex:4168
+#: lib/glossia_web/live/dashboard_live.ex:4209
+#: lib/glossia_web/live/dashboard_live.ex:4800
+#: lib/glossia_web/live/dashboard_live.ex:4841
 #, elixir-autogen, elixir-format
 msgid "By"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3087
+#: lib/glossia_web/live/dashboard_live.ex:3607
 #, elixir-autogen, elixir-format
 msgid "Event"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3148
+#: lib/glossia_web/live/dashboard_live.ex:3668
 #, elixir-autogen, elixir-format
 msgid "Events will appear here as you and your team make changes."
 msgstr ""
@@ -793,12 +798,12 @@ msgstr ""
 msgid "Sign in"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3117
+#: lib/glossia_web/live/dashboard_live.ex:3637
 #, elixir-autogen, elixir-format
 msgid "System"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3529
+#: lib/glossia_web/live/dashboard_live.ex:4049
 #, elixir-autogen, elixir-format
 msgid "New override"
 msgstr ""
@@ -808,7 +813,7 @@ msgstr ""
 msgid "Clear all"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3081
+#: lib/glossia_web/live/dashboard_live.ex:3601
 #, elixir-autogen, elixir-format
 msgid "Event type"
 msgstr ""
@@ -823,7 +828,7 @@ msgstr ""
 msgid "Remove filter"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3078
+#: lib/glossia_web/live/dashboard_live.ex:3598
 #, elixir-autogen, elixir-format
 msgid "Search events..."
 msgstr ""
@@ -833,26 +838,26 @@ msgstr ""
 msgid "Search..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3635
-#: lib/glossia_web/live/dashboard_live.ex:4266
+#: lib/glossia_web/live/dashboard_live.ex:4155
+#: lib/glossia_web/live/dashboard_live.ex:4786
 #, elixir-autogen, elixir-format
 msgid "Version"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:261
+#: lib/glossia_web/live/dashboard_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Voice #%{version}"
 msgstr ""
 
-#: lib/glossia_web/components/layouts/platform.html.heex:323
-#: lib/glossia_web/live/dashboard_live.ex:86
-#: lib/glossia_web/live/dashboard_live.ex:98
-#: lib/glossia_web/live/dashboard_live.ex:3070
+#: lib/glossia_web/components/layouts/platform.html.heex:354
+#: lib/glossia_web/live/dashboard_live.ex:95
+#: lib/glossia_web/live/dashboard_live.ex:107
+#: lib/glossia_web/live/dashboard_live.ex:3590
 #, elixir-autogen, elixir-format
 msgid "Logs"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3147
+#: lib/glossia_web/live/dashboard_live.ex:3667
 #, elixir-autogen, elixir-format
 msgid "No logs yet"
 msgstr ""
@@ -870,27 +875,27 @@ msgstr ""
 #: lib/glossia_web/components/layouts/admin.html.heex:6
 #: lib/glossia_web/components/layouts/platform.html.heex:104
 #: lib/glossia_web/components/layouts/user_profile.html.heex:16
-#: lib/glossia_web/live/dashboard_live.ex:4548
+#: lib/glossia_web/live/dashboard_live.ex:5068
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1632
+#: lib/glossia_web/live/dashboard_live.ex:1837
 #, elixir-autogen, elixir-format
 msgid "An invitation is already pending for this email."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4612
+#: lib/glossia_web/live/dashboard_live.ex:5132
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to remove this member?"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1635
+#: lib/glossia_web/live/dashboard_live.ex:1840
 #, elixir-autogen, elixir-format
 msgid "Could not send invitation."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4560
+#: lib/glossia_web/live/dashboard_live.ex:5080
 #, elixir-autogen, elixir-format
 msgid "Current members"
 msgstr ""
@@ -900,14 +905,14 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4531
+#: lib/glossia_web/live/dashboard_live.ex:5051
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4649
-#: lib/glossia_web/live/dashboard_live.ex:4845
-#: lib/glossia_web/live/dashboard_live.ex:5019
+#: lib/glossia_web/live/dashboard_live.ex:5169
+#: lib/glossia_web/live/dashboard_live.ex:5365
+#: lib/glossia_web/live/dashboard_live.ex:5539
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr ""
@@ -922,12 +927,12 @@ msgstr ""
 msgid "Invitation declined."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1665
+#: lib/glossia_web/live/dashboard_live.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Invitation revoked."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1620
+#: lib/glossia_web/live/dashboard_live.ex:1825
 #, elixir-autogen, elixir-format
 msgid "Invitation sent to %{email}."
 msgstr ""
@@ -937,72 +942,75 @@ msgstr ""
 msgid "Invitation to %{org}"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4522
+#: lib/glossia_web/live/dashboard_live.ex:5042
 #, elixir-autogen, elixir-format
 msgid "Invite a new member"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4640
+#: lib/glossia_web/live/dashboard_live.ex:5160
 #, elixir-autogen, elixir-format
 msgid "Invited by"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4596
+#: lib/glossia_web/live/dashboard_live.ex:5116
 #, elixir-autogen, elixir-format
 msgid "Joined"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4545
+#: lib/glossia_web/live/dashboard_live.ex:5065
 #, elixir-autogen, elixir-format
 msgid "Member"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1718
+#: lib/glossia_web/live/dashboard_live.ex:1923
 #, elixir-autogen, elixir-format
 msgid "Member removed."
 msgstr ""
 
-#: lib/glossia_web/components/layouts/platform.html.heex:315
-#: lib/glossia_web/live/dashboard_live.ex:436
-#: lib/glossia_web/live/dashboard_live.ex:454
-#: lib/glossia_web/live/dashboard_live.ex:4517
+#: lib/glossia_web/components/layouts/platform.html.heex:346
+#: lib/glossia_web/live/dashboard_live.ex:445
+#: lib/glossia_web/live/dashboard_live.ex:463
+#: lib/glossia_web/live/dashboard_live.ex:5037
 #, elixir-autogen, elixir-format
 msgid "Members"
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:365
-#: lib/glossia_web/live/dashboard_live.ex:2996
-#: lib/glossia_web/live/dashboard_live.ex:4574
-#: lib/glossia_web/live/dashboard_live.ex:4728
-#: lib/glossia_web/live/dashboard_live.ex:4816
-#: lib/glossia_web/live/dashboard_live.ex:4993
-#: lib/glossia_web/live/dashboard_live.ex:5333
-#: lib/glossia_web/live/dashboard_live.ex:5648
+#: lib/glossia_web/live/dashboard_live.ex:3488
+#: lib/glossia_web/live/dashboard_live.ex:5094
+#: lib/glossia_web/live/dashboard_live.ex:5248
+#: lib/glossia_web/live/dashboard_live.ex:5336
+#: lib/glossia_web/live/dashboard_live.ex:5513
+#: lib/glossia_web/live/dashboard_live.ex:5853
+#: lib/glossia_web/live/dashboard_live.ex:6168
+#: lib/glossia_web/live/dashboard_live.ex:10160
+#: lib/glossia_web/live/dashboard_live.ex:10225
+#: lib/glossia_web/live/dashboard_live.ex:10427
 #: lib/glossia_web/live/profile_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4623
+#: lib/glossia_web/live/dashboard_live.ex:5143
 #, elixir-autogen, elixir-format
 msgid "Pending invitations"
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:389
-#: lib/glossia_web/live/dashboard_live.ex:4665
+#: lib/glossia_web/live/dashboard_live.ex:5185
 #, elixir-autogen, elixir-format
 msgid "Revoke"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4542
-#: lib/glossia_web/live/dashboard_live.ex:4568
-#: lib/glossia_web/live/dashboard_live.ex:4589
-#: lib/glossia_web/live/dashboard_live.ex:4635
+#: lib/glossia_web/live/dashboard_live.ex:5062
+#: lib/glossia_web/live/dashboard_live.ex:5088
+#: lib/glossia_web/live/dashboard_live.ex:5109
+#: lib/glossia_web/live/dashboard_live.ex:5155
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4554
+#: lib/glossia_web/live/dashboard_live.ex:5074
 #, elixir-autogen, elixir-format
 msgid "Send invitation"
 msgstr ""
@@ -1050,7 +1058,7 @@ msgstr ""
 msgid "This invitation is not valid."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1628
+#: lib/glossia_web/live/dashboard_live.ex:1833
 #, elixir-autogen, elixir-format
 msgid "This user is already a member."
 msgstr ""
@@ -1060,30 +1068,36 @@ msgstr ""
 msgid "You are already a member of this organization."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1235
-#: lib/glossia_web/live/dashboard_live.ex:1247
-#: lib/glossia_web/live/dashboard_live.ex:1251
-#: lib/glossia_web/live/dashboard_live.ex:1379
-#: lib/glossia_web/live/dashboard_live.ex:1392
-#: lib/glossia_web/live/dashboard_live.ex:1396
-#: lib/glossia_web/live/dashboard_live.ex:1604
-#: lib/glossia_web/live/dashboard_live.ex:1642
-#: lib/glossia_web/live/dashboard_live.ex:1676
-#: lib/glossia_web/live/dashboard_live.ex:1759
-#: lib/glossia_web/live/dashboard_live.ex:1795
-#: lib/glossia_web/live/dashboard_live.ex:1843
-#: lib/glossia_web/live/dashboard_live.ex:1897
-#: lib/glossia_web/live/dashboard_live.ex:1929
-#: lib/glossia_web/live/dashboard_live.ex:1957
-#: lib/glossia_web/live/dashboard_live.ex:1985
-#: lib/glossia_web/live/dashboard_live.ex:2053
-#: lib/glossia_web/live/dashboard_live.ex:2083
-#: lib/glossia_web/live/dashboard_live.ex:2130
-#: lib/glossia_web/live/dashboard_live.ex:2156
-#: lib/glossia_web/live/dashboard_live.ex:2172
-#: lib/glossia_web/live/dashboard_live.ex:2370
-#: lib/glossia_web/live/dashboard_live.ex:7978
-#: lib/glossia_web/live/dashboard_live.ex:8047
+#: lib/glossia_web/live/dashboard_live.ex:1440
+#: lib/glossia_web/live/dashboard_live.ex:1452
+#: lib/glossia_web/live/dashboard_live.ex:1456
+#: lib/glossia_web/live/dashboard_live.ex:1584
+#: lib/glossia_web/live/dashboard_live.ex:1597
+#: lib/glossia_web/live/dashboard_live.ex:1601
+#: lib/glossia_web/live/dashboard_live.ex:1809
+#: lib/glossia_web/live/dashboard_live.ex:1847
+#: lib/glossia_web/live/dashboard_live.ex:1881
+#: lib/glossia_web/live/dashboard_live.ex:1964
+#: lib/glossia_web/live/dashboard_live.ex:2000
+#: lib/glossia_web/live/dashboard_live.ex:2048
+#: lib/glossia_web/live/dashboard_live.ex:2102
+#: lib/glossia_web/live/dashboard_live.ex:2134
+#: lib/glossia_web/live/dashboard_live.ex:2162
+#: lib/glossia_web/live/dashboard_live.ex:2190
+#: lib/glossia_web/live/dashboard_live.ex:2255
+#: lib/glossia_web/live/dashboard_live.ex:2283
+#: lib/glossia_web/live/dashboard_live.ex:2311
+#: lib/glossia_web/live/dashboard_live.ex:2360
+#: lib/glossia_web/live/dashboard_live.ex:2396
+#: lib/glossia_web/live/dashboard_live.ex:2431
+#: lib/glossia_web/live/dashboard_live.ex:2524
+#: lib/glossia_web/live/dashboard_live.ex:2554
+#: lib/glossia_web/live/dashboard_live.ex:2601
+#: lib/glossia_web/live/dashboard_live.ex:2627
+#: lib/glossia_web/live/dashboard_live.ex:2643
+#: lib/glossia_web/live/dashboard_live.ex:2841
+#: lib/glossia_web/live/dashboard_live.ex:8498
+#: lib/glossia_web/live/dashboard_live.ex:8567
 #, elixir-autogen, elixir-format
 msgid "You don't have permission."
 msgstr ""
@@ -1113,7 +1127,7 @@ msgstr ""
 msgid "You have joined %{org}."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4538
+#: lib/glossia_web/live/dashboard_live.ex:5058
 #, elixir-autogen, elixir-format
 msgid "colleague@example.com"
 msgstr ""
@@ -1133,12 +1147,12 @@ msgstr ""
 msgid "Previous page"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4628
+#: lib/glossia_web/live/dashboard_live.ex:5148
 #, elixir-autogen, elixir-format
 msgid "Search invitations..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4565
+#: lib/glossia_web/live/dashboard_live.ex:5085
 #, elixir-autogen, elixir-format
 msgid "Search members..."
 msgstr ""
@@ -1148,18 +1162,18 @@ msgstr ""
 msgid "Showing %{first}-%{last} of %{total}"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4250
+#: lib/glossia_web/live/dashboard_live.ex:4770
 #, elixir-autogen, elixir-format
 msgid "Add term"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1698
+#: lib/glossia_web/live/dashboard_live.ex:1903
 #, elixir-autogen, elixir-format
 msgid "Cannot remove the only admin of the organization."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4116
-#: lib/glossia_web/live/dashboard_live.ex:7209
+#: lib/glossia_web/live/dashboard_live.ex:4636
+#: lib/glossia_web/live/dashboard_live.ex:7729
 #, elixir-autogen, elixir-format
 msgid "Case sensitive"
 msgstr ""
@@ -1172,56 +1186,59 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4144
+#: lib/glossia_web/live/dashboard_live.ex:4664
 #, elixir-autogen, elixir-format
 msgid "Context or description (optional)"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1668
+#: lib/glossia_web/live/dashboard_live.ex:1873
 #, elixir-autogen, elixir-format
 msgid "Could not revoke invitation."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4059
+#: lib/glossia_web/live/dashboard_live.ex:4579
 #, elixir-autogen, elixir-format
 msgid "Define canonical terms and their approved translations per language. Terms are matched during content processing to ensure consistent terminology."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4139
-#: lib/glossia_web/live/dashboard_live.ex:4464
-#: lib/glossia_web/live/dashboard_live.ex:7220
+#: lib/glossia_web/live/dashboard_live.ex:4659
+#: lib/glossia_web/live/dashboard_live.ex:4984
+#: lib/glossia_web/live/dashboard_live.ex:7740
+#: lib/glossia_web/live/dashboard_live.ex:10333
+#: lib/glossia_web/live/dashboard_live.ex:10471
+#: lib/glossia_web/live/dashboard_live.ex:10538
 #, elixir-autogen, elixir-format
 msgid "Definition"
 msgstr ""
 
 #: lib/glossia_web/components/layouts/platform.html.heex:246
 #: lib/glossia_web/controllers/page_html/home.html.heex:431
-#: lib/glossia_web/live/dashboard_live.ex:293
-#: lib/glossia_web/live/dashboard_live.ex:316
-#: lib/glossia_web/live/dashboard_live.ex:385
-#: lib/glossia_web/live/dashboard_live.ex:411
-#: lib/glossia_web/live/dashboard_live.ex:3971
-#: lib/glossia_web/live/dashboard_live.ex:8351
+#: lib/glossia_web/live/dashboard_live.ex:302
+#: lib/glossia_web/live/dashboard_live.ex:325
+#: lib/glossia_web/live/dashboard_live.ex:394
+#: lib/glossia_web/live/dashboard_live.ex:420
+#: lib/glossia_web/live/dashboard_live.ex:4491
+#: lib/glossia_web/live/dashboard_live.ex:8871
 #, elixir-autogen, elixir-format
 msgid "Glossary"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:406
+#: lib/glossia_web/live/dashboard_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "Glossary #%{version}"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4423
+#: lib/glossia_web/live/dashboard_live.ex:4943
 #, elixir-autogen, elixir-format
 msgid "Glossary entries in this version."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1649
+#: lib/glossia_web/live/dashboard_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "Invitation not found."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4077
+#: lib/glossia_web/live/dashboard_live.ex:4597
 #, elixir-autogen, elixir-format
 msgid "New term"
 msgstr ""
@@ -1234,13 +1251,13 @@ msgstr ""
 #: lib/glossia_web/live/admin_live.ex:370
 #: lib/glossia_web/live/admin_live.ex:375
 #: lib/glossia_web/live/admin_live.ex:496
-#: lib/glossia_web/live/dashboard_live.ex:4123
-#: lib/glossia_web/live/dashboard_live.ex:7214
+#: lib/glossia_web/live/dashboard_live.ex:4643
+#: lib/glossia_web/live/dashboard_live.ex:7734
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4263
+#: lib/glossia_web/live/dashboard_live.ex:4783
 #, elixir-autogen, elixir-format
 msgid "Previous versions of your glossary."
 msgstr ""
@@ -1250,42 +1267,48 @@ msgstr ""
 msgid "Search language..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4097
-#: lib/glossia_web/live/dashboard_live.ex:7203
+#: lib/glossia_web/live/dashboard_live.ex:4617
+#: lib/glossia_web/live/dashboard_live.ex:7723
+#: lib/glossia_web/live/dashboard_live.ex:10332
 #, elixir-autogen, elixir-format
 msgid "Term"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4057
-#: lib/glossia_web/live/dashboard_live.ex:4422
+#: lib/glossia_web/live/dashboard_live.ex:4577
+#: lib/glossia_web/live/dashboard_live.ex:4942
 #, elixir-autogen, elixir-format
 msgid "Terms"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4212
+#: lib/glossia_web/live/dashboard_live.ex:4732
+#: lib/glossia_web/live/dashboard_live.ex:10490
+#: lib/glossia_web/live/dashboard_live.ex:10558
 #, elixir-autogen, elixir-format
 msgid "Translation"
 msgstr ""
 
 #: lib/glossia_web/components/layouts/platform.html.heex:157
-#: lib/glossia_web/live/dashboard_live.ex:965
-#: lib/glossia_web/live/dashboard_live.ex:983
-#: lib/glossia_web/live/dashboard_live.ex:987
-#: lib/glossia_web/live/dashboard_live.ex:4151
-#: lib/glossia_web/live/dashboard_live.ex:4469
-#: lib/glossia_web/live/dashboard_live.ex:5813
-#: lib/glossia_web/live/dashboard_live.ex:7228
+#: lib/glossia_web/live/dashboard_live.ex:1170
+#: lib/glossia_web/live/dashboard_live.ex:1188
+#: lib/glossia_web/live/dashboard_live.ex:1192
+#: lib/glossia_web/live/dashboard_live.ex:4671
+#: lib/glossia_web/live/dashboard_live.ex:4989
+#: lib/glossia_web/live/dashboard_live.ex:6333
+#: lib/glossia_web/live/dashboard_live.ex:7748
+#: lib/glossia_web/live/dashboard_live.ex:10334
+#: lib/glossia_web/live/dashboard_live.ex:10475
+#: lib/glossia_web/live/dashboard_live.ex:10542
 #, elixir-autogen, elixir-format
 msgid "Translations"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1691
+#: lib/glossia_web/live/dashboard_live.ex:1896
 #, elixir-autogen, elixir-format
 msgid "User is not a member."
 msgstr ""
 
 #: lib/glossia_web/controllers/admin/impersonation_controller.ex:51
-#: lib/glossia_web/live/dashboard_live.ex:1683
+#: lib/glossia_web/live/dashboard_live.ex:1888
 #, elixir-autogen, elixir-format
 msgid "User not found."
 msgstr ""
@@ -1293,18 +1316,18 @@ msgstr ""
 #: lib/glossia_web/live/admin_live.ex:370
 #: lib/glossia_web/live/admin_live.ex:375
 #: lib/glossia_web/live/admin_live.ex:496
-#: lib/glossia_web/live/dashboard_live.ex:4126
-#: lib/glossia_web/live/dashboard_live.ex:7212
+#: lib/glossia_web/live/dashboard_live.ex:4646
+#: lib/glossia_web/live/dashboard_live.ex:7732
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1688
+#: lib/glossia_web/live/dashboard_live.ex:1893
 #, elixir-autogen, elixir-format
 msgid "You can't remove yourself."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4102
+#: lib/glossia_web/live/dashboard_live.ex:4622
 #, elixir-autogen, elixir-format
 msgid "e.g. API, workspace, deploy"
 msgstr ""
@@ -1347,22 +1370,22 @@ msgstr ""
 msgid "Ready to get started?"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3977
+#: lib/glossia_web/live/dashboard_live.ex:4497
 #, elixir-autogen, elixir-format
 msgid "Approved terms and translations to keep your content consistent."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3071
+#: lib/glossia_web/live/dashboard_live.ex:3591
 #, elixir-autogen, elixir-format
 msgid "Audit trail of actions and events for this account."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3199
+#: lib/glossia_web/live/dashboard_live.ex:3719
 #, elixir-autogen, elixir-format
 msgid "Define the tone, formality, and style guidelines for your content."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4518
+#: lib/glossia_web/live/dashboard_live.ex:5038
 #, elixir-autogen, elixir-format
 msgid "Manage who has access to this account."
 msgstr ""
@@ -1404,11 +1427,12 @@ msgstr ""
 #: lib/glossia_web/live/admin_live.ex:378
 #: lib/glossia_web/live/admin_live.ex:501
 #: lib/glossia_web/live/admin_live.ex:765
-#: lib/glossia_web/live/dashboard_live.ex:3025
-#: lib/glossia_web/live/dashboard_live.ex:5346
-#: lib/glossia_web/live/dashboard_live.ex:5843
-#: lib/glossia_web/live/dashboard_live.ex:9601
-#: lib/glossia_web/live/dashboard_live.ex:9655
+#: lib/glossia_web/live/dashboard_live.ex:3517
+#: lib/glossia_web/live/dashboard_live.ex:5866
+#: lib/glossia_web/live/dashboard_live.ex:6363
+#: lib/glossia_web/live/dashboard_live.ex:10182
+#: lib/glossia_web/live/dashboard_live.ex:10625
+#: lib/glossia_web/live/dashboard_live.ex:10679
 #, elixir-autogen, elixir-format
 msgid "Created"
 msgstr ""
@@ -1451,7 +1475,7 @@ msgstr ""
 #: lib/glossia_web/components/layouts/admin.html.heex:27
 #: lib/glossia_web/components/layouts/platform.html.heex:139
 #: lib/glossia_web/live/admin_live.ex:323
-#: lib/glossia_web/live/dashboard_live.ex:837
+#: lib/glossia_web/live/dashboard_live.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
@@ -1482,7 +1506,7 @@ msgid "System-wide metrics at a glance."
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:486
-#: lib/glossia_web/live/dashboard_live.ex:9593
+#: lib/glossia_web/live/dashboard_live.ex:10617
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr ""
@@ -1496,6 +1520,9 @@ msgid "Users"
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:491
+#: lib/glossia_web/live/dashboard_live.ex:10174
+#: lib/glossia_web/live/dashboard_live.ex:10240
+#: lib/glossia_web/live/dashboard_live.ex:10439
 #, elixir-autogen, elixir-format
 msgid "Visibility"
 msgstr ""
@@ -1505,311 +1532,314 @@ msgstr ""
 msgid "You do not have permission to access this page."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4751
+#: lib/glossia_web/live/dashboard_live.ex:5271
 #, elixir-autogen, elixir-format
 msgid "30 days"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4752
+#: lib/glossia_web/live/dashboard_live.ex:5272
 #, elixir-autogen, elixir-format
 msgid "60 days"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4753
+#: lib/glossia_web/live/dashboard_live.ex:5273
 #, elixir-autogen, elixir-format
 msgid "90 days"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2005
+#: lib/glossia_web/live/dashboard_live.ex:2210
 #, elixir-autogen, elixir-format
 msgid "Application deleted."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5087
-#: lib/glossia_web/live/dashboard_live.ex:5181
+#: lib/glossia_web/live/dashboard_live.ex:5607
+#: lib/glossia_web/live/dashboard_live.ex:5701
 #, elixir-autogen, elixir-format
 msgid "Application details"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5097
-#: lib/glossia_web/live/dashboard_live.ex:5195
+#: lib/glossia_web/live/dashboard_live.ex:5617
+#: lib/glossia_web/live/dashboard_live.ex:5715
 #, elixir-autogen, elixir-format
 msgid "Application name"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1946
+#: lib/glossia_web/live/dashboard_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Application updated."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5278
+#: lib/glossia_web/live/dashboard_live.ex:5798
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete this application? This action cannot be undone."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4919
+#: lib/glossia_web/live/dashboard_live.ex:5439
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to revoke this token? Any applications using this token will no longer be able to access the API."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5255
+#: lib/glossia_web/live/dashboard_live.ex:5775
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Existing integrations using the current secret will stop working."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5125
-#: lib/glossia_web/live/dashboard_live.ex:5223
+#: lib/glossia_web/live/dashboard_live.ex:5645
+#: lib/glossia_web/live/dashboard_live.ex:5743
 #, elixir-autogen, elixir-format
 msgid "Authorization callback URL"
 msgstr ""
 
 #: lib/glossia_web/components/dashboard_components.ex:857
 #: lib/glossia_web/live/admin_live.ex:452
-#: lib/glossia_web/live/dashboard_live.ex:3723
-#: lib/glossia_web/live/dashboard_live.ex:4355
-#: lib/glossia_web/live/dashboard_live.ex:9739
-#: lib/glossia_web/live/dashboard_live.ex:9882
+#: lib/glossia_web/live/dashboard_live.ex:4243
+#: lib/glossia_web/live/dashboard_live.ex:4875
+#: lib/glossia_web/live/dashboard_live.ex:10763
+#: lib/glossia_web/live/dashboard_live.ex:10906
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5186
-#: lib/glossia_web/live/dashboard_live.ex:5314
-#: lib/glossia_web/live/dashboard_live.ex:5341
+#: lib/glossia_web/live/dashboard_live.ex:5706
+#: lib/glossia_web/live/dashboard_live.ex:5834
+#: lib/glossia_web/live/dashboard_live.ex:5861
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5247
+#: lib/glossia_web/live/dashboard_live.ex:5767
 #, elixir-autogen, elixir-format
 msgid "Client secret"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1975
+#: lib/glossia_web/live/dashboard_live.ex:2180
 #, elixir-autogen, elixir-format
 msgid "Client secret regenerated."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4960
-#: lib/glossia_web/live/dashboard_live.ex:5167
+#: lib/glossia_web/live/dashboard_live.ex:5480
+#: lib/glossia_web/live/dashboard_live.ex:5687
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1922
+#: lib/glossia_web/live/dashboard_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Could not create application."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1836
+#: lib/glossia_web/live/dashboard_live.ex:2041
 #, elixir-autogen, elixir-format
 msgid "Could not create token."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2009
+#: lib/glossia_web/live/dashboard_live.ex:2214
 #, elixir-autogen, elixir-format
 msgid "Could not delete application."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1978
+#: lib/glossia_web/live/dashboard_live.ex:2183
 #, elixir-autogen, elixir-format
 msgid "Could not regenerate secret."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1950
+#: lib/glossia_web/live/dashboard_live.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Could not update application."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5266
+#: lib/glossia_web/live/dashboard_live.ex:5786
+#: lib/glossia_web/live/dashboard_live.ex:10402
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5283
+#: lib/glossia_web/live/dashboard_live.ex:5803
 #, elixir-autogen, elixir-format
 msgid "Delete application"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5268
+#: lib/glossia_web/live/dashboard_live.ex:5788
 #, elixir-autogen, elixir-format
 msgid "Deleting this application will revoke all tokens issued through it and break any integrations using it."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3251
-#: lib/glossia_web/live/dashboard_live.ex:3294
-#: lib/glossia_web/live/dashboard_live.ex:3794
-#: lib/glossia_web/live/dashboard_live.ex:4029
-#: lib/glossia_web/live/dashboard_live.ex:4739
-#: lib/glossia_web/live/dashboard_live.ex:4826
-#: lib/glossia_web/live/dashboard_live.ex:5107
-#: lib/glossia_web/live/dashboard_live.ex:5205
-#: lib/glossia_web/live/dashboard_live.ex:5658
-#: lib/glossia_web/live/dashboard_live.ex:7089
-#: lib/glossia_web/live/dashboard_live.ex:9726
+#: lib/glossia_web/live/dashboard_live.ex:3771
+#: lib/glossia_web/live/dashboard_live.ex:3814
+#: lib/glossia_web/live/dashboard_live.ex:4314
+#: lib/glossia_web/live/dashboard_live.ex:4549
+#: lib/glossia_web/live/dashboard_live.ex:5259
+#: lib/glossia_web/live/dashboard_live.ex:5346
+#: lib/glossia_web/live/dashboard_live.ex:5627
+#: lib/glossia_web/live/dashboard_live.ex:5725
+#: lib/glossia_web/live/dashboard_live.ex:6178
+#: lib/glossia_web/live/dashboard_live.ex:7609
+#: lib/glossia_web/live/dashboard_live.ex:10229
+#: lib/glossia_web/live/dashboard_live.ex:10429
+#: lib/glossia_web/live/dashboard_live.ex:10750
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4749
+#: lib/glossia_web/live/dashboard_live.ex:5269
 #, elixir-autogen, elixir-format
 msgid "Expiration"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4939
+#: lib/glossia_web/live/dashboard_live.ex:5459
 #, elixir-autogen, elixir-format
 msgid "Generate new token"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4723
+#: lib/glossia_web/live/dashboard_live.ex:5243
 #, elixir-autogen, elixir-format
 msgid "Give your token a descriptive name and select the scopes it needs."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5115
-#: lib/glossia_web/live/dashboard_live.ex:5213
+#: lib/glossia_web/live/dashboard_live.ex:5635
+#: lib/glossia_web/live/dashboard_live.ex:5733
 #, elixir-autogen, elixir-format
 msgid "Homepage URL"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5010
+#: lib/glossia_web/live/dashboard_live.ex:5530
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5308
+#: lib/glossia_web/live/dashboard_live.ex:5828
 #, elixir-autogen, elixir-format
 msgid "Make sure to copy your client secret now. You will not be able to see it again."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5154
+#: lib/glossia_web/live/dashboard_live.ex:5674
 #, elixir-autogen, elixir-format
 msgid "Make sure to copy your new client secret now. You will not be able to see it again."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4851
-#: lib/glossia_web/live/dashboard_live.ex:5016
-#: lib/glossia_web/live/dashboard_live.ex:5025
+#: lib/glossia_web/live/dashboard_live.ex:5371
+#: lib/glossia_web/live/dashboard_live.ex:5536
+#: lib/glossia_web/live/dashboard_live.ex:5545
 #, elixir-autogen, elixir-format
 msgid "Never"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:571
+#: lib/glossia_web/live/dashboard_live.ex:580
 #, elixir-autogen, elixir-format
 msgid "New OAuth App"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5368
+#: lib/glossia_web/live/dashboard_live.ex:5888
 #, elixir-autogen, elixir-format
 msgid "No OAuth applications yet"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4754
+#: lib/glossia_web/live/dashboard_live.ex:5274
 #, elixir-autogen, elixir-format
 msgid "No expiration"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5045
+#: lib/glossia_web/live/dashboard_live.ex:5565
 #, elixir-autogen, elixir-format
 msgid "No tokens yet"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:554
+#: lib/glossia_web/live/dashboard_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "OAuth Apps"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5288
+#: lib/glossia_web/live/dashboard_live.ex:5808
 #, elixir-autogen, elixir-format
 msgid "OAuth applications"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5290
+#: lib/glossia_web/live/dashboard_live.ex:5810
 #, elixir-autogen, elixir-format
 msgid "OAuth applications allow external services to access Glossia on behalf of users."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5260
+#: lib/glossia_web/live/dashboard_live.ex:5780
 #, elixir-autogen, elixir-format
 msgid "Regenerate client secret"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5248
+#: lib/glossia_web/live/dashboard_live.ex:5768
 #, elixir-autogen, elixir-format
 msgid "Regenerate the client secret if you believe it has been compromised."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5077
+#: lib/glossia_web/live/dashboard_live.ex:5597
 #, elixir-autogen, elixir-format
 msgid "Register a new OAuth application"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5089
+#: lib/glossia_web/live/dashboard_live.ex:5609
 #, elixir-autogen, elixir-format
 msgid "Register an OAuth application to allow users to sign in with Glossia or to let external services access your account."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5370
+#: lib/glossia_web/live/dashboard_live.ex:5890
 #, elixir-autogen, elixir-format
 msgid "Register an OAuth application to enable 'Sign in with Glossia' or to let external services access your account."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5300
+#: lib/glossia_web/live/dashboard_live.ex:5820
 #, elixir-autogen, elixir-format
 msgid "Register new application"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4768
-#: lib/glossia_web/live/dashboard_live.ex:4865
-#: lib/glossia_web/live/dashboard_live.ex:5001
+#: lib/glossia_web/live/dashboard_live.ex:5288
+#: lib/glossia_web/live/dashboard_live.ex:5385
+#: lib/glossia_web/live/dashboard_live.ex:5521
 #, elixir-autogen, elixir-format
 msgid "Scopes"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4770
-#: lib/glossia_web/live/dashboard_live.ex:4867
+#: lib/glossia_web/live/dashboard_live.ex:5290
+#: lib/glossia_web/live/dashboard_live.ex:5387
 #, elixir-autogen, elixir-format
 msgid "Select the permissions this token should have. Only grant the minimum scopes needed."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5135
+#: lib/glossia_web/live/dashboard_live.ex:5655
 #, elixir-autogen, elixir-format
 msgid "The URL where users will be redirected after authorization."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4722
-#: lib/glossia_web/live/dashboard_live.ex:4811
+#: lib/glossia_web/live/dashboard_live.ex:5242
+#: lib/glossia_web/live/dashboard_live.ex:5331
 #, elixir-autogen, elixir-format
 msgid "Token details"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1866
+#: lib/glossia_web/live/dashboard_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "Token not found."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1862
+#: lib/glossia_web/live/dashboard_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "Token revoked."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4757
+#: lib/glossia_web/live/dashboard_live.ex:5277
 #, elixir-autogen, elixir-format
 msgid "Tokens with no expiration are a security risk."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4931
+#: lib/glossia_web/live/dashboard_live.ex:5451
 #, elixir-autogen, elixir-format
 msgid "Tokens you have generated that can be used to access the Glossia API."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4745
-#: lib/glossia_web/live/dashboard_live.ex:4832
+#: lib/glossia_web/live/dashboard_live.ex:5265
+#: lib/glossia_web/live/dashboard_live.ex:5352
 #, elixir-autogen, elixir-format
 msgid "What is this token for?"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4735
+#: lib/glossia_web/live/dashboard_live.ex:5255
 #, elixir-autogen, elixir-format
 msgid "e.g. CI Pipeline Token"
 msgstr ""
@@ -1819,22 +1849,22 @@ msgstr ""
 msgid "A reason is required to impersonate a user."
 msgstr ""
 
-#: lib/glossia_web/components/layouts/platform.html.heex:383
-#: lib/glossia_web/live/dashboard_live.ex:475
-#: lib/glossia_web/live/dashboard_live.ex:483
-#: lib/glossia_web/live/dashboard_live.ex:503
-#: lib/glossia_web/live/dashboard_live.ex:532
-#: lib/glossia_web/live/dashboard_live.ex:4929
+#: lib/glossia_web/components/layouts/platform.html.heex:414
+#: lib/glossia_web/live/dashboard_live.ex:484
+#: lib/glossia_web/live/dashboard_live.ex:492
+#: lib/glossia_web/live/dashboard_live.ex:512
+#: lib/glossia_web/live/dashboard_live.ex:541
+#: lib/glossia_web/live/dashboard_live.ex:5449
 #, elixir-autogen, elixir-format
 msgid "Account tokens"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5046
+#: lib/glossia_web/live/dashboard_live.ex:5566
 #, elixir-autogen, elixir-format
 msgid "Account tokens allow you to authenticate with the Glossia API."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5318
+#: lib/glossia_web/live/dashboard_live.ex:5838
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
 msgstr ""
@@ -1855,13 +1885,13 @@ msgstr ""
 msgid "Impersonation ended. You are back to your admin account."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4947
+#: lib/glossia_web/live/dashboard_live.ex:5467
 #, elixir-autogen, elixir-format
 msgid "Make sure to copy your account token now. You will not be able to see it again."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:493
-#: lib/glossia_web/live/dashboard_live.ex:4712
+#: lib/glossia_web/live/dashboard_live.ex:502
+#: lib/glossia_web/live/dashboard_live.ex:5232
 #, elixir-autogen, elixir-format
 msgid "New account token"
 msgstr ""
@@ -1886,12 +1916,12 @@ msgstr ""
 msgid "Reason for impersonation..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5329
+#: lib/glossia_web/live/dashboard_live.ex:5849
 #, elixir-autogen, elixir-format
 msgid "Search applications..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4989
+#: lib/glossia_web/live/dashboard_live.ex:5509
 #, elixir-autogen, elixir-format
 msgid "Search tokens..."
 msgstr ""
@@ -1913,17 +1943,17 @@ msgstr ""
 msgid "You are now impersonating %{email}."
 msgstr ""
 
-#: lib/glossia_web/components/layouts/platform.html.heex:392
-#: lib/glossia_web/live/dashboard_live.ex:561
-#: lib/glossia_web/live/dashboard_live.ex:579
-#: lib/glossia_web/live/dashboard_live.ex:618
+#: lib/glossia_web/components/layouts/platform.html.heex:423
+#: lib/glossia_web/live/dashboard_live.ex:570
+#: lib/glossia_web/live/dashboard_live.ex:588
+#: lib/glossia_web/live/dashboard_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "OAuth apps"
 msgstr ""
 
-#: lib/glossia_web/components/layouts/platform.html.heex:295
+#: lib/glossia_web/components/layouts/platform.html.heex:326
 #: lib/glossia_web/live/admin_live.ex:755
-#: lib/glossia_web/live/dashboard_live.ex:2973
+#: lib/glossia_web/live/dashboard_live.ex:3465
 #: lib/glossia_web/live/profile_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Account"
@@ -1934,24 +1964,24 @@ msgstr ""
 msgid "Breadcrumbs"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9717
+#: lib/glossia_web/live/dashboard_live.ex:10741
 #, elixir-autogen, elixir-format
 msgid "Brief summary..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:580
+#: lib/glossia_web/live/dashboard_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "New application"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:504
+#: lib/glossia_web/live/dashboard_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "New token"
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:869
-#: lib/glossia_web/live/dashboard_live.ex:9587
-#: lib/glossia_web/live/dashboard_live.ex:9898
+#: lib/glossia_web/live/dashboard_live.ex:10611
+#: lib/glossia_web/live/dashboard_live.ex:10922
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
@@ -1961,7 +1991,7 @@ msgstr ""
 msgid "Opened %{date}"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9731
+#: lib/glossia_web/live/dashboard_live.ex:10755
 #, elixir-autogen, elixir-format
 msgid "Provide details..."
 msgstr ""
@@ -1977,24 +2007,24 @@ msgid "Search by title..."
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:758
-#: lib/glossia_web/live/dashboard_live.ex:3011
-#: lib/glossia_web/live/dashboard_live.ex:5798
-#: lib/glossia_web/live/dashboard_live.ex:5828
-#: lib/glossia_web/live/dashboard_live.ex:6361
-#: lib/glossia_web/live/dashboard_live.ex:9584
-#: lib/glossia_web/live/dashboard_live.ex:9650
+#: lib/glossia_web/live/dashboard_live.ex:3503
+#: lib/glossia_web/live/dashboard_live.ex:6318
+#: lib/glossia_web/live/dashboard_live.ex:6348
+#: lib/glossia_web/live/dashboard_live.ex:6881
+#: lib/glossia_web/live/dashboard_live.ex:10608
+#: lib/glossia_web/live/dashboard_live.ex:10674
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:750
-#: lib/glossia_web/live/dashboard_live.ex:3240
-#: lib/glossia_web/live/dashboard_live.ex:3688
-#: lib/glossia_web/live/dashboard_live.ex:4018
-#: lib/glossia_web/live/dashboard_live.ex:4320
-#: lib/glossia_web/live/dashboard_live.ex:9581
-#: lib/glossia_web/live/dashboard_live.ex:9635
-#: lib/glossia_web/live/dashboard_live.ex:9707
+#: lib/glossia_web/live/dashboard_live.ex:3760
+#: lib/glossia_web/live/dashboard_live.ex:4208
+#: lib/glossia_web/live/dashboard_live.ex:4538
+#: lib/glossia_web/live/dashboard_live.ex:4840
+#: lib/glossia_web/live/dashboard_live.ex:10605
+#: lib/glossia_web/live/dashboard_live.ex:10659
+#: lib/glossia_web/live/dashboard_live.ex:10731
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -2004,7 +2034,7 @@ msgstr ""
 msgid "Chat with the team, share feedback, and connect with other builders using Glossia."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1788
+#: lib/glossia_web/live/dashboard_live.ex:1993
 #, elixir-autogen, elixir-format
 msgid "Could not update token."
 msgstr ""
@@ -2014,7 +2044,7 @@ msgstr ""
 msgid "From builders who worked at"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9716
+#: lib/glossia_web/live/dashboard_live.ex:10740
 #, elixir-autogen, elixir-format
 msgid "Generating..."
 msgstr ""
@@ -2034,23 +2064,23 @@ msgstr ""
 msgid "Join the community"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4907
-#: lib/glossia_web/live/dashboard_live.ex:4924
+#: lib/glossia_web/live/dashboard_live.ex:5427
+#: lib/glossia_web/live/dashboard_live.ex:5444
 #, elixir-autogen, elixir-format
 msgid "Revoke token"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4909
+#: lib/glossia_web/live/dashboard_live.ex:5429
 #, elixir-autogen, elixir-format
 msgid "Revoking this token will immediately prevent any applications using it from accessing the API."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4836
+#: lib/glossia_web/live/dashboard_live.ex:5356
 #, elixir-autogen, elixir-format
 msgid "Token prefix"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1784
+#: lib/glossia_web/live/dashboard_live.ex:1989
 #, elixir-autogen, elixir-format
 msgid "Token updated."
 msgstr ""
@@ -2085,56 +2115,56 @@ msgstr ""
 msgid "Where do humans participate?"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3351
+#: lib/glossia_web/live/dashboard_live.ex:3871
 #, elixir-autogen, elixir-format
 msgid "AI-generated cultural notes per country. You can edit them."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3284
-#: lib/glossia_web/live/dashboard_live.ex:3788
+#: lib/glossia_web/live/dashboard_live.ex:3804
+#: lib/glossia_web/live/dashboard_live.ex:4308
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3299
+#: lib/glossia_web/live/dashboard_live.ex:3819
 #, elixir-autogen, elixir-format
 msgid "Briefly describe what you do and who you serve..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3346
-#: lib/glossia_web/live/dashboard_live.ex:7130
+#: lib/glossia_web/live/dashboard_live.ex:3866
+#: lib/glossia_web/live/dashboard_live.ex:7650
 #, elixir-autogen, elixir-format
 msgid "Cultural notes"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3370
+#: lib/glossia_web/live/dashboard_live.ex:3890
 #, elixir-autogen, elixir-format
 msgid "Cultural notes for %{country}..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3285
+#: lib/glossia_web/live/dashboard_live.ex:3805
 #, elixir-autogen, elixir-format
 msgid "Describe what you do and which countries you target."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3789
+#: lib/glossia_web/live/dashboard_live.ex:4309
 #, elixir-autogen, elixir-format
 msgid "Description and target countries for this version."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3349
+#: lib/glossia_web/live/dashboard_live.ex:3869
 #, elixir-autogen, elixir-format
 msgid "Generating cultural notes..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3807
-#: lib/glossia_web/live/dashboard_live.ex:7524
-#: lib/glossia_web/live/dashboard_live.ex:7535
+#: lib/glossia_web/live/dashboard_live.ex:4327
+#: lib/glossia_web/live/dashboard_live.ex:8044
+#: lib/glossia_web/live/dashboard_live.ex:8055
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3324
+#: lib/glossia_web/live/dashboard_live.ex:3844
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr ""
@@ -2144,14 +2174,14 @@ msgstr ""
 msgid "Search country..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3312
-#: lib/glossia_web/live/dashboard_live.ex:3799
-#: lib/glossia_web/live/dashboard_live.ex:7124
+#: lib/glossia_web/live/dashboard_live.ex:3832
+#: lib/glossia_web/live/dashboard_live.ex:4319
+#: lib/glossia_web/live/dashboard_live.ex:7644
 #, elixir-autogen, elixir-format
 msgid "Target countries"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3304
+#: lib/glossia_web/live/dashboard_live.ex:3824
 #, elixir-autogen, elixir-format
 msgid "Used to generate cultural notes for target countries."
 msgstr ""
@@ -2202,8 +2232,8 @@ msgstr ""
 msgid "All of your linguistic preferences live in one place. Every team draws from the same foundation, so your organization sounds consistent whether it is a product screen, a marketing campaign, or a support reply."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5449
-#: lib/glossia_web/live/dashboard_live.ex:6980
+#: lib/glossia_web/live/dashboard_live.ex:5969
+#: lib/glossia_web/live/dashboard_live.ex:7500
 #, elixir-autogen, elixir-format
 msgid "An error occurred during setup."
 msgstr ""
@@ -2249,13 +2279,13 @@ msgid "Built on the foundation, ready for your use cases"
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:870
-#: lib/glossia_web/live/dashboard_live.ex:9588
-#: lib/glossia_web/live/dashboard_live.ex:9899
+#: lib/glossia_web/live/dashboard_live.ex:10612
+#: lib/glossia_web/live/dashboard_live.ex:10923
 #, elixir-autogen, elixir-format
 msgid "Closed"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9885
+#: lib/glossia_web/live/dashboard_live.ex:10909
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr ""
@@ -2272,7 +2302,7 @@ msgstr ""
 msgid "Connect your writing platforms, content systems, and AI assistants to your organization's linguistic knowledge."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5516
+#: lib/glossia_web/live/dashboard_live.ex:6036
 #, elixir-autogen, elixir-format
 msgid "Connected to"
 msgstr ""
@@ -2293,7 +2323,7 @@ msgid "Continue"
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:285
-#: lib/glossia_web/live/dashboard_live.ex:2103
+#: lib/glossia_web/live/dashboard_live.ex:2574
 #, elixir-autogen, elixir-format
 msgid "Could not add comment."
 msgstr ""
@@ -2308,12 +2338,12 @@ msgstr ""
 msgid "Could not deny the device request."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2225
+#: lib/glossia_web/live/dashboard_live.ex:2696
 #, elixir-autogen, elixir-format
 msgid "Could not disconnect GitHub."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2326
+#: lib/glossia_web/live/dashboard_live.ex:2797
 #, elixir-autogen, elixir-format
 msgid "Could not import repository."
 msgstr ""
@@ -2323,7 +2353,7 @@ msgstr ""
 msgid "Create an organization, invite your team, and organize work into projects. Each project has its own voices, glossaries, and rules that linguists iterate on together."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9684
+#: lib/glossia_web/live/dashboard_live.ex:10708
 #, elixir-autogen, elixir-format
 msgid "Create one to track a bug, suggestion, or discussion."
 msgstr ""
@@ -2333,7 +2363,7 @@ msgstr ""
 msgid "Deny"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9697
+#: lib/glossia_web/live/dashboard_live.ex:10721
 #, elixir-autogen, elixir-format
 msgid "Describe what you want to report or discuss."
 msgstr ""
@@ -2373,7 +2403,7 @@ msgstr ""
 msgid "GitHub connected successfully."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2221
+#: lib/glossia_web/live/dashboard_live.ex:2692
 #, elixir-autogen, elixir-format
 msgid "GitHub disconnected."
 msgstr ""
@@ -2391,11 +2421,6 @@ msgstr ""
 #: lib/glossia_web/controllers/page_html/home.html.heex:381
 #, elixir-autogen, elixir-format
 msgid "Global definitions on Glossia set the baseline for your organization. Project-level context narrows the scope. The result: every agent gets exactly the right instructions without you repeating yourself."
-msgstr ""
-
-#: lib/glossia_web/controllers/page_html/home.html.heex:6
-#, elixir-autogen, elixir-format
-msgid "Glossia captures your voice, terminology, and tone in one place so linguists and teams can shape how your organization speaks across every language and surface."
 msgstr ""
 
 #: lib/glossia_web/controllers/page_html/home.html.heex:168
@@ -2425,7 +2450,7 @@ msgstr ""
 msgid "Language managers"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9875
+#: lib/glossia_web/live/dashboard_live.ex:10899
 #, elixir-autogen, elixir-format
 msgid "Leave a comment..."
 msgstr ""
@@ -2481,7 +2506,7 @@ msgstr ""
 msgid "Open integrations"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9778
+#: lib/glossia_web/live/dashboard_live.ex:10802
 #, elixir-autogen, elixir-format
 msgid "Opened by %{author} on %{date}"
 msgstr ""
@@ -2531,37 +2556,37 @@ msgstr ""
 msgid "Refine voice definitions, update glossaries, and review content directly. Your expertise becomes the foundation that agents and integrations draw from across every project."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6565
+#: lib/glossia_web/live/dashboard_live.ex:7085
 #, elixir-autogen, elixir-format
 msgid "Search repositories..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5403
-#: lib/glossia_web/live/dashboard_live.ex:6875
+#: lib/glossia_web/live/dashboard_live.ex:5923
+#: lib/glossia_web/live/dashboard_live.ex:7395
 #, elixir-autogen, elixir-format
 msgid "Setting up localization..."
 msgstr ""
 
 #: lib/glossia_web/components/layouts/platform.html.heex:108
 #: lib/glossia_web/components/layouts/platform.html.heex:167
-#: lib/glossia_web/components/layouts/platform.html.heex:361
+#: lib/glossia_web/components/layouts/platform.html.heex:392
 #: lib/glossia_web/components/layouts/user_profile.html.heex:5
 #: lib/glossia_web/components/layouts/user_profile.html.heex:20
 #: lib/glossia_web/components/layouts/user_profile.html.heex:28
-#: lib/glossia_web/live/dashboard_live.ex:482
-#: lib/glossia_web/live/dashboard_live.ex:502
-#: lib/glossia_web/live/dashboard_live.ex:531
-#: lib/glossia_web/live/dashboard_live.ex:560
-#: lib/glossia_web/live/dashboard_live.ex:578
-#: lib/glossia_web/live/dashboard_live.ex:617
-#: lib/glossia_web/live/dashboard_live.ex:883
-#: lib/glossia_web/live/dashboard_live.ex:890
+#: lib/glossia_web/live/dashboard_live.ex:491
+#: lib/glossia_web/live/dashboard_live.ex:511
+#: lib/glossia_web/live/dashboard_live.ex:540
+#: lib/glossia_web/live/dashboard_live.ex:569
+#: lib/glossia_web/live/dashboard_live.ex:587
+#: lib/glossia_web/live/dashboard_live.ex:626
+#: lib/glossia_web/live/dashboard_live.ex:1088
+#: lib/glossia_web/live/dashboard_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5447
-#: lib/glossia_web/live/dashboard_live.ex:6977
+#: lib/glossia_web/live/dashboard_live.ex:5967
+#: lib/glossia_web/live/dashboard_live.ex:7497
 #, elixir-autogen, elixir-format
 msgid "Setup failed"
 msgstr ""
@@ -2621,7 +2646,7 @@ msgstr ""
 msgid "Toggle sidebar"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9609
+#: lib/glossia_web/live/dashboard_live.ex:10633
 #, elixir-autogen, elixir-format
 msgid "Track bugs, suggestions, and discussions."
 msgstr ""
@@ -2692,7 +2717,7 @@ msgstr ""
 msgid "and open standards like"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9813
+#: lib/glossia_web/live/dashboard_live.ex:10837
 #, elixir-autogen, elixir-format
 msgid "Comments (%{count})"
 msgstr ""
@@ -2707,12 +2732,12 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6587
+#: lib/glossia_web/live/dashboard_live.ex:7107
 #, elixir-autogen, elixir-format
 msgid "No matching repositories"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9627
+#: lib/glossia_web/live/dashboard_live.ex:10651
 #, elixir-autogen, elixir-format
 msgid "Number"
 msgstr ""
@@ -2722,19 +2747,19 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9842
+#: lib/glossia_web/live/dashboard_live.ex:10866
 #, elixir-autogen, elixir-format
 msgid "Quote reply"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3004
-#: lib/glossia_web/live/dashboard_live.ex:6480
-#: lib/glossia_web/live/dashboard_live.ex:6577
+#: lib/glossia_web/live/dashboard_live.ex:3496
+#: lib/glossia_web/live/dashboard_live.ex:7000
+#: lib/glossia_web/live/dashboard_live.ex:7097
 #, elixir-autogen, elixir-format
 msgid "Repository"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2989
+#: lib/glossia_web/live/dashboard_live.ex:3481
 #, elixir-autogen, elixir-format
 msgid "Search projects..."
 msgstr ""
@@ -2744,19 +2769,19 @@ msgstr ""
 msgid "Sign in to continue."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6588
-#: lib/glossia_web/live/dashboard_live.ex:6804
+#: lib/glossia_web/live/dashboard_live.ex:7108
+#: lib/glossia_web/live/dashboard_live.ex:7324
 #, elixir-autogen, elixir-format
 msgid "Try adjusting your search query."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5455
-#: lib/glossia_web/live/dashboard_live.ex:6986
+#: lib/glossia_web/live/dashboard_live.ex:5975
+#: lib/glossia_web/live/dashboard_live.ex:7506
 #, elixir-autogen, elixir-format
 msgid "View agent session"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5487
+#: lib/glossia_web/live/dashboard_live.ex:6007
 #, elixir-autogen, elixir-format
 msgid "View setup session"
 msgstr ""
@@ -2766,312 +2791,312 @@ msgstr ""
 msgid "Write"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5643
-#: lib/glossia_web/live/dashboard_live.ex:9596
-#: lib/glossia_web/live/dashboard_live.ex:9908
+#: lib/glossia_web/live/dashboard_live.ex:6163
+#: lib/glossia_web/live/dashboard_live.ex:10620
+#: lib/glossia_web/live/dashboard_live.ex:10932
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:4309
+#: lib/glossia_web/live/dashboard_live.ex:4829
 #, elixir-autogen, elixir-format
 msgid "Pending glossary proposals from contributors."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3677
+#: lib/glossia_web/live/dashboard_live.ex:4197
 #, elixir-autogen, elixir-format
 msgid "Pending voice proposals from contributors."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3996
-#: lib/glossia_web/live/dashboard_live.ex:8356
+#: lib/glossia_web/live/dashboard_live.ex:4516
+#: lib/glossia_web/live/dashboard_live.ex:8876
 #, elixir-autogen, elixir-format
 msgid "glossary"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3218
+#: lib/glossia_web/live/dashboard_live.ex:3738
 #, elixir-autogen, elixir-format
 msgid "voice"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3256
-#: lib/glossia_web/live/dashboard_live.ex:4034
+#: lib/glossia_web/live/dashboard_live.ex:3776
+#: lib/glossia_web/live/dashboard_live.ex:4554
 #, elixir-autogen, elixir-format
 msgid "Explain what should change and why..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3234
-#: lib/glossia_web/live/dashboard_live.ex:4012
+#: lib/glossia_web/live/dashboard_live.ex:3754
+#: lib/glossia_web/live/dashboard_live.ex:4532
 #, elixir-autogen, elixir-format
 msgid "Provide a clear title, full context, and a concise summary of intent."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:7627
+#: lib/glossia_web/live/dashboard_live.ex:8147
 #, elixir-autogen, elixir-format
 msgid "Changed"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:7143
+#: lib/glossia_web/live/dashboard_live.ex:7663
 #, elixir-autogen, elixir-format
 msgid "No proposed changes detected."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:7175
+#: lib/glossia_web/live/dashboard_live.ex:7695
 #, elixir-autogen, elixir-format
 msgid "No proposed glossary changes detected."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:7081
-#: lib/glossia_web/live/dashboard_live.ex:7165
+#: lib/glossia_web/live/dashboard_live.ex:7601
+#: lib/glossia_web/live/dashboard_live.ex:7685
 #, elixir-autogen, elixir-format
 msgid "Proposed changes"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:7082
+#: lib/glossia_web/live/dashboard_live.ex:7602
 #, elixir-autogen, elixir-format
 msgid "This review is read-only. Go back to continue editing your draft."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:7626
+#: lib/glossia_web/live/dashboard_live.ex:8146
 #, elixir-autogen, elixir-format
 msgid "Updated"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:7132
+#: lib/glossia_web/live/dashboard_live.ex:7652
 #, elixir-autogen, elixir-format
 msgid "Updated for: %{countries}"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5663
+#: lib/glossia_web/live/dashboard_live.ex:6183
 #, elixir-autogen, elixir-format
 msgid "A brief description of this project"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5551
+#: lib/glossia_web/live/dashboard_live.ex:6071
 #: lib/glossia_web/live/profile_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5626
+#: lib/glossia_web/live/dashboard_live.ex:6146
 #, elixir-autogen, elixir-format
 msgid "Click to upload"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2181
+#: lib/glossia_web/live/dashboard_live.ex:2652
 #, elixir-autogen, elixir-format
 msgid "Could not apply suggestion."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2414
+#: lib/glossia_web/live/dashboard_live.ex:2885
 #, elixir-autogen, elixir-format
 msgid "Could not update project settings."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3976
+#: lib/glossia_web/live/dashboard_live.ex:4496
 #, elixir-autogen, elixir-format
 msgid "Create a suggestion with title, description, and proposed glossary updates."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3198
+#: lib/glossia_web/live/dashboard_live.ex:3718
 #, elixir-autogen, elixir-format
 msgid "Create a suggestion with title, description, and proposed voice updates."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8393
+#: lib/glossia_web/live/dashboard_live.ex:8913
 #, elixir-autogen, elixir-format
 msgid "Failed to submit glossary suggestion."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8332
+#: lib/glossia_web/live/dashboard_live.ex:8852
 #, elixir-autogen, elixir-format
 msgid "Failed to submit voice suggestion."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5701
+#: lib/glossia_web/live/dashboard_live.ex:6221
 #, elixir-autogen, elixir-format
 msgid "File is too large (max 5 MB)"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5702
+#: lib/glossia_web/live/dashboard_live.ex:6222
 #, elixir-autogen, elixir-format
 msgid "File type not accepted"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8406
-#: lib/glossia_web/live/dashboard_live.ex:9598
-#: lib/glossia_web/live/dashboard_live.ex:9907
+#: lib/glossia_web/live/dashboard_live.ex:8926
+#: lib/glossia_web/live/dashboard_live.ex:10622
+#: lib/glossia_web/live/dashboard_live.ex:10931
 #, elixir-autogen, elixir-format
 msgid "Glossary suggestion"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2178
+#: lib/glossia_web/live/dashboard_live.ex:2649
 #, elixir-autogen, elixir-format
 msgid "Invalid suggestion payload."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5540
+#: lib/glossia_web/live/dashboard_live.ex:6060
 #, elixir-autogen, elixir-format
 msgid "Manage your project details and appearance."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3676
-#: lib/glossia_web/live/dashboard_live.ex:4308
+#: lib/glossia_web/live/dashboard_live.ex:4196
+#: lib/glossia_web/live/dashboard_live.ex:4828
 #, elixir-autogen, elixir-format
 msgid "Open suggestions"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5606
+#: lib/glossia_web/live/dashboard_live.ex:6126
 #, elixir-autogen, elixir-format
 msgid "Project avatar"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5539
+#: lib/glossia_web/live/dashboard_live.ex:6059
 #, elixir-autogen, elixir-format
 msgid "Project settings"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2410
+#: lib/glossia_web/live/dashboard_live.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Project settings updated."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3726
-#: lib/glossia_web/live/dashboard_live.ex:4358
+#: lib/glossia_web/live/dashboard_live.ex:4246
+#: lib/glossia_web/live/dashboard_live.ex:4878
 #, elixir-autogen, elixir-format
 msgid "Submit suggestion"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:242
-#: lib/glossia_web/live/dashboard_live.ex:387
-#: lib/glossia_web/live/dashboard_live.ex:3208
-#: lib/glossia_web/live/dashboard_live.ex:3739
-#: lib/glossia_web/live/dashboard_live.ex:3986
-#: lib/glossia_web/live/dashboard_live.ex:4371
+#: lib/glossia_web/live/dashboard_live.ex:251
+#: lib/glossia_web/live/dashboard_live.ex:396
+#: lib/glossia_web/live/dashboard_live.ex:3728
+#: lib/glossia_web/live/dashboard_live.ex:4259
+#: lib/glossia_web/live/dashboard_live.ex:4506
+#: lib/glossia_web/live/dashboard_live.ex:4891
 #, elixir-autogen, elixir-format
 msgid "Suggest changes"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:363
-#: lib/glossia_web/live/dashboard_live.ex:3971
+#: lib/glossia_web/live/dashboard_live.ex:372
+#: lib/glossia_web/live/dashboard_live.ex:4491
 #, elixir-autogen, elixir-format
 msgid "Suggest glossary changes"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:213
-#: lib/glossia_web/live/dashboard_live.ex:3195
+#: lib/glossia_web/live/dashboard_live.ex:222
+#: lib/glossia_web/live/dashboard_live.ex:3715
 #, elixir-autogen, elixir-format
 msgid "Suggest voice changes"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3232
-#: lib/glossia_web/live/dashboard_live.ex:4010
+#: lib/glossia_web/live/dashboard_live.ex:3752
+#: lib/glossia_web/live/dashboard_live.ex:4530
 #, elixir-autogen, elixir-format
 msgid "Suggestion details"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:7167
+#: lib/glossia_web/live/dashboard_live.ex:7687
 #, elixir-autogen, elixir-format
 msgid "This review is read-only and mirrors the glossary editor layout. Go back to continue editing your draft."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5703
+#: lib/glossia_web/live/dashboard_live.ex:6223
 #, elixir-autogen, elixir-format
 msgid "Too many files"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5552
+#: lib/glossia_web/live/dashboard_live.ex:6072
 #, elixir-autogen, elixir-format
 msgid "Upload an image to represent this project."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5704
+#: lib/glossia_web/live/dashboard_live.ex:6224
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9597
-#: lib/glossia_web/live/dashboard_live.ex:9906
+#: lib/glossia_web/live/dashboard_live.ex:10621
+#: lib/glossia_web/live/dashboard_live.ex:10930
 #, elixir-autogen, elixir-format
 msgid "Voice suggestion"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8466
+#: lib/glossia_web/live/dashboard_live.ex:8986
 #, elixir-autogen, elixir-format
 msgid "suggestion"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6099
+#: lib/glossia_web/live/dashboard_live.ex:6619
 #, elixir-autogen, elixir-format
 msgid "%{count}d ago"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6098
+#: lib/glossia_web/live/dashboard_live.ex:6618
 #, elixir-autogen, elixir-format
 msgid "%{count}h ago"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6097
+#: lib/glossia_web/live/dashboard_live.ex:6617
 #, elixir-autogen, elixir-format
 msgid "%{count}m ago"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1257
-#: lib/glossia_web/live/dashboard_live.ex:1402
+#: lib/glossia_web/live/dashboard_live.ex:1462
+#: lib/glossia_web/live/dashboard_live.ex:1607
 #, elixir-autogen, elixir-format
 msgid "A suggestion description is required."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1254
-#: lib/glossia_web/live/dashboard_live.ex:1399
+#: lib/glossia_web/live/dashboard_live.ex:1459
+#: lib/glossia_web/live/dashboard_live.ex:1604
 #, elixir-autogen, elixir-format
 msgid "A suggestion title is required."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8563
+#: lib/glossia_web/live/dashboard_live.ex:9083
 #, elixir-autogen, elixir-format
 msgid "Applied glossary suggestion as version #%{version}."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8585
+#: lib/glossia_web/live/dashboard_live.ex:9105
 #, elixir-autogen, elixir-format
 msgid "Applied this suggestion as glossary version #%{version}."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8582
+#: lib/glossia_web/live/dashboard_live.ex:9102
 #, elixir-autogen, elixir-format
 msgid "Applied this suggestion as voice version #%{version}."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8523
+#: lib/glossia_web/live/dashboard_live.ex:9043
 #, elixir-autogen, elixir-format
 msgid "Applied voice suggestion as version #%{version}."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9790
+#: lib/glossia_web/live/dashboard_live.ex:10814
 #, elixir-autogen, elixir-format
 msgid "Apply suggestion"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:1011
-#: lib/glossia_web/live/dashboard_live.ex:1019
+#: lib/glossia_web/live/dashboard_live.ex:1216
+#: lib/glossia_web/live/dashboard_live.ex:1224
 #, elixir-autogen, elixir-format
 msgid "Could not load commits from GitHub."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3246
-#: lib/glossia_web/live/dashboard_live.ex:4024
+#: lib/glossia_web/live/dashboard_live.ex:3766
+#: lib/glossia_web/live/dashboard_live.ex:4544
 #, elixir-autogen, elixir-format
 msgid "Short summary of the suggested change"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3680
-#: lib/glossia_web/live/dashboard_live.ex:4312
+#: lib/glossia_web/live/dashboard_live.ex:4200
+#: lib/glossia_web/live/dashboard_live.ex:4832
 #, elixir-autogen, elixir-format
 msgid "Suggestion"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6096
+#: lib/glossia_web/live/dashboard_live.ex:6616
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -3082,46 +3107,46 @@ msgid "%{count} discussions total"
 msgstr ""
 
 #: lib/glossia_web/components/layouts/platform.html.heex:148
-#: lib/glossia_web/live/dashboard_live.ex:917
-#: lib/glossia_web/live/dashboard_live.ex:928
-#: lib/glossia_web/live/dashboard_live.ex:5710
+#: lib/glossia_web/live/dashboard_live.ex:1122
+#: lib/glossia_web/live/dashboard_live.ex:1133
+#: lib/glossia_web/live/dashboard_live.ex:6230
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5747
+#: lib/glossia_web/live/dashboard_live.ex:6267
 #, elixir-autogen, elixir-format
 msgid "Author"
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:802
-#: lib/glossia_web/live/dashboard_live.ex:9796
+#: lib/glossia_web/live/dashboard_live.ex:10820
 #, elixir-autogen, elixir-format
 msgid "Close discussion"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5726
-#: lib/glossia_web/live/dashboard_live.ex:5836
+#: lib/glossia_web/live/dashboard_live.ex:6246
+#: lib/glossia_web/live/dashboard_live.ex:6356
 #, elixir-autogen, elixir-format
 msgid "Commit"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5907
+#: lib/glossia_web/live/dashboard_live.ex:6427
 #, elixir-autogen, elixir-format
 msgid "Completed %{time}"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2127
+#: lib/glossia_web/live/dashboard_live.ex:2598
 #, elixir-autogen, elixir-format
 msgid "Could not close discussion."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5716
+#: lib/glossia_web/live/dashboard_live.ex:6236
 #, elixir-autogen, elixir-format
 msgid "Could not load activity from GitHub."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2153
+#: lib/glossia_web/live/dashboard_live.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Could not reopen discussion."
 msgstr ""
@@ -3131,7 +3156,7 @@ msgstr ""
 msgid "Discussion closed."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2067
+#: lib/glossia_web/live/dashboard_live.ex:2538
 #, elixir-autogen, elixir-format
 msgid "Discussion created."
 msgstr ""
@@ -3147,14 +3172,14 @@ msgid "Discussion reopened."
 msgstr ""
 
 #: lib/glossia_web/components/layouts/admin.html.heex:86
-#: lib/glossia_web/components/layouts/platform.html.heex:271
+#: lib/glossia_web/components/layouts/platform.html.heex:302
 #: lib/glossia_web/live/admin_live.ex:96
 #: lib/glossia_web/live/admin_live.ex:730
-#: lib/glossia_web/live/dashboard_live.ex:750
-#: lib/glossia_web/live/dashboard_live.ex:756
-#: lib/glossia_web/live/dashboard_live.ex:776
-#: lib/glossia_web/live/dashboard_live.ex:795
-#: lib/glossia_web/live/dashboard_live.ex:9608
+#: lib/glossia_web/live/dashboard_live.ex:955
+#: lib/glossia_web/live/dashboard_live.ex:961
+#: lib/glossia_web/live/dashboard_live.ex:981
+#: lib/glossia_web/live/dashboard_live.ex:1000
+#: lib/glossia_web/live/dashboard_live.ex:10632
 #, elixir-autogen, elixir-format
 msgid "Discussions"
 msgstr ""
@@ -3169,26 +3194,26 @@ msgstr ""
 msgid "Failed to reopen discussion."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8386
+#: lib/glossia_web/live/dashboard_live.ex:8906
 #, elixir-autogen, elixir-format
 msgid "Glossary suggestion submitted as discussion #%{number}."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5831
-#: lib/glossia_web/live/dashboard_live.ex:6489
+#: lib/glossia_web/live/dashboard_live.ex:6351
+#: lib/glossia_web/live/dashboard_live.ex:7009
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:767
-#: lib/glossia_web/live/dashboard_live.ex:777
-#: lib/glossia_web/live/dashboard_live.ex:9614
-#: lib/glossia_web/live/dashboard_live.ex:9696
+#: lib/glossia_web/live/dashboard_live.ex:972
+#: lib/glossia_web/live/dashboard_live.ex:982
+#: lib/glossia_web/live/dashboard_live.ex:10638
+#: lib/glossia_web/live/dashboard_live.ex:10720
 #, elixir-autogen, elixir-format
 msgid "New discussion"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5784
+#: lib/glossia_web/live/dashboard_live.ex:6304
 #, elixir-autogen, elixir-format
 msgid "No commits yet."
 msgstr ""
@@ -3198,188 +3223,188 @@ msgstr ""
 msgid "No discussions found."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9683
+#: lib/glossia_web/live/dashboard_live.ex:10707
 #, elixir-autogen, elixir-format
 msgid "No discussions yet"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5917
+#: lib/glossia_web/live/dashboard_live.ex:6437
 #, elixir-autogen, elixir-format
 msgid "No events recorded yet."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5861
+#: lib/glossia_web/live/dashboard_live.ex:6381
 #, elixir-autogen, elixir-format
 msgid "No translation sessions yet."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8470
+#: lib/glossia_web/live/dashboard_live.ex:8990
 #, elixir-autogen, elixir-format
 msgid "Proposed %{resource} update.\n\nChange note: %{note}\n\nUse the discussion action to apply this suggestion when ready."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5711
+#: lib/glossia_web/live/dashboard_live.ex:6231
 #, elixir-autogen, elixir-format
 msgid "Recent content activity for this project."
 msgstr ""
 
 #: lib/glossia_web/live/admin_live.ex:810
-#: lib/glossia_web/live/dashboard_live.ex:9802
+#: lib/glossia_web/live/dashboard_live.ex:10826
 #, elixir-autogen, elixir-format
 msgid "Reopen discussion"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:966
+#: lib/glossia_web/live/dashboard_live.ex:1171
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5875
+#: lib/glossia_web/live/dashboard_live.ex:6395
 #, elixir-autogen, elixir-format
 msgid "Session for commit %{sha}"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5904
+#: lib/glossia_web/live/dashboard_live.ex:6424
 #, elixir-autogen, elixir-format
 msgid "Started %{time}"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:9742
+#: lib/glossia_web/live/dashboard_live.ex:10766
 #, elixir-autogen, elixir-format
 msgid "Submit new discussion"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2175
+#: lib/glossia_web/live/dashboard_live.ex:2646
 #, elixir-autogen, elixir-format
 msgid "This discussion is not a suggestion."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5776
+#: lib/glossia_web/live/dashboard_live.ex:6296
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:959
-#: lib/glossia_web/live/dashboard_live.ex:5872
+#: lib/glossia_web/live/dashboard_live.ex:1164
+#: lib/glossia_web/live/dashboard_live.ex:6392
 #, elixir-autogen, elixir-format
 msgid "Translation session"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5876
+#: lib/glossia_web/live/dashboard_live.ex:6396
 #, elixir-autogen, elixir-format
 msgid "Translation session details"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5814
+#: lib/glossia_web/live/dashboard_live.ex:6334
 #, elixir-autogen, elixir-format
 msgid "Translation sessions for this project."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:8327
+#: lib/glossia_web/live/dashboard_live.ex:8847
 #, elixir-autogen, elixir-format
 msgid "Voice suggestion submitted as discussion #%{number}."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6732
+#: lib/glossia_web/live/dashboard_live.ex:7252
 #, elixir-autogen, elixir-format
 msgid "%{count} language selected"
 msgid_plural "%{count} languages selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6745
+#: lib/glossia_web/live/dashboard_live.ex:7265
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5803
+#: lib/glossia_web/live/dashboard_live.ex:6323
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5804
+#: lib/glossia_web/live/dashboard_live.ex:6324
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6952
-#: lib/glossia_web/live/dashboard_live.ex:7001
+#: lib/glossia_web/live/dashboard_live.ex:7472
+#: lib/glossia_web/live/dashboard_live.ex:7521
 #, elixir-autogen, elixir-format
 msgid "Go to project"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6470
+#: lib/glossia_web/live/dashboard_live.ex:6990
 #, elixir-autogen, elixir-format
 msgid "Import a GitHub repository and set up localization."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6686
+#: lib/glossia_web/live/dashboard_live.ex:7206
 #, elixir-autogen, elixir-format
 msgid "Install GitHub App"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5801
+#: lib/glossia_web/live/dashboard_live.ex:6321
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:7006
+#: lib/glossia_web/live/dashboard_live.ex:7526
 #, elixir-autogen, elixir-format
 msgid "Preparing..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5802
+#: lib/glossia_web/live/dashboard_live.ex:6322
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6780
+#: lib/glossia_web/live/dashboard_live.ex:7300
 #, elixir-autogen, elixir-format
 msgid "Search languages..."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6619
+#: lib/glossia_web/live/dashboard_live.ex:7139
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6753
+#: lib/glossia_web/live/dashboard_live.ex:7273
 #, elixir-autogen, elixir-format
 msgid "Set up project"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6494
+#: lib/glossia_web/live/dashboard_live.ex:7014
 #, elixir-autogen, elixir-format
 msgid "Setup"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6917
+#: lib/glossia_web/live/dashboard_live.ex:7437
 #, elixir-autogen, elixir-format
 msgid "Setup complete"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6795
+#: lib/glossia_web/live/dashboard_live.ex:7315
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6635
-#: lib/glossia_web/live/dashboard_live.ex:6664
+#: lib/glossia_web/live/dashboard_live.ex:7155
+#: lib/glossia_web/live/dashboard_live.ex:7184
 #, elixir-autogen, elixir-format
 msgid "Configure repository access"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6678
+#: lib/glossia_web/live/dashboard_live.ex:7198
 #, elixir-autogen, elixir-format
 msgid "Connect a Git provider"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6630
+#: lib/glossia_web/live/dashboard_live.ex:7150
 #, elixir-autogen, elixir-format
 msgid "Don't see your repository?"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3173
+#: lib/glossia_web/live/dashboard_live.ex:3693
 #, elixir-autogen, elixir-format
 msgid "Draft your %{resource} updates here. When you're ready, use the bottom bar to open a suggestion with title and details."
 msgstr ""
@@ -3389,7 +3414,7 @@ msgstr ""
 msgid "GitHub App is not configured. Set GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, and GITHUB_APP_SLUG."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6680
+#: lib/glossia_web/live/dashboard_live.ex:7200
 #, elixir-autogen, elixir-format
 msgid "Install the Glossia GitHub App to import repositories and set up localization."
 msgstr ""
@@ -3404,17 +3429,17 @@ msgstr ""
 msgid "Manage your personal profile and account information."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6794
+#: lib/glossia_web/live/dashboard_live.ex:7314
 #, elixir-autogen, elixir-format
 msgid "Native name"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6803
+#: lib/glossia_web/live/dashboard_live.ex:7323
 #, elixir-autogen, elixir-format
 msgid "No matching languages"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6654
+#: lib/glossia_web/live/dashboard_live.ex:7174
 #, elixir-autogen, elixir-format
 msgid "No repositories accessible"
 msgstr ""
@@ -3427,28 +3452,28 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:2974
+#: lib/glossia_web/live/dashboard_live.ex:3466
 #, elixir-autogen, elixir-format
 msgid "Projects and integrations connected to this account."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3738
-#: lib/glossia_web/live/dashboard_live.ex:4370
+#: lib/glossia_web/live/dashboard_live.ex:4258
+#: lib/glossia_web/live/dashboard_live.ex:4890
 #, elixir-autogen, elixir-format
 msgid "Ready to suggest changes"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:3171
+#: lib/glossia_web/live/dashboard_live.ex:3691
 #, elixir-autogen, elixir-format
 msgid "Suggestion mode"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6656
+#: lib/glossia_web/live/dashboard_live.ex:7176
 #, elixir-autogen, elixir-format
 msgid "The GitHub App is installed but has no accessible repositories. Configure the installation to grant access to the repositories you want to import."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:627
+#: lib/glossia_web/live/dashboard_live.ex:636
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to create projects here."
 msgstr ""
@@ -3521,7 +3546,7 @@ msgstr ""
 msgid "Your display name"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6367
+#: lib/glossia_web/live/dashboard_live.ex:6887
 #, elixir-autogen, elixir-format
 msgid "Agent"
 msgstr ""
@@ -3534,7 +3559,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6346
+#: lib/glossia_web/live/dashboard_live.ex:6866
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
@@ -3544,19 +3569,19 @@ msgstr ""
 msgid "No connections yet. Connect a third-party service by signing in through it."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5469
-#: lib/glossia_web/live/dashboard_live.ex:6234
-#: lib/glossia_web/live/dashboard_live.ex:6925
+#: lib/glossia_web/live/dashboard_live.ex:5989
+#: lib/glossia_web/live/dashboard_live.ex:6754
+#: lib/glossia_web/live/dashboard_live.ex:7445
 #, elixir-autogen, elixir-format
 msgid "Open pull request"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6364
+#: lib/glossia_web/live/dashboard_live.ex:6884
 #, elixir-autogen, elixir-format
 msgid "Plan"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6349
+#: lib/glossia_web/live/dashboard_live.ex:6869
 #, elixir-autogen, elixir-format
 msgid "Prompt"
 msgstr ""
@@ -3566,18 +3591,18 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6352
+#: lib/glossia_web/live/dashboard_live.ex:6872
 #, elixir-autogen, elixir-format
 msgid "Pull request"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5467
-#: lib/glossia_web/live/dashboard_live.ex:6923
+#: lib/glossia_web/live/dashboard_live.ex:5987
+#: lib/glossia_web/live/dashboard_live.ex:7443
 #, elixir-autogen, elixir-format
 msgid "Pull request ready"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6232
+#: lib/glossia_web/live/dashboard_live.ex:6752
 #, elixir-autogen, elixir-format
 msgid "Pull request ready for review and merge."
 msgstr ""
@@ -3587,49 +3612,49 @@ msgstr ""
 msgid "Settings navigation"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6355
+#: lib/glossia_web/live/dashboard_live.ex:6875
 #, elixir-autogen, elixir-format
 msgid "Tool"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6358
+#: lib/glossia_web/live/dashboard_live.ex:6878
 #, elixir-autogen, elixir-format
 msgid "Tool output"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6370
+#: lib/glossia_web/live/dashboard_live.ex:6890
 #, elixir-autogen, elixir-format
 msgid "Update"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6918
+#: lib/glossia_web/live/dashboard_live.ex:7438
 #, elixir-autogen, elixir-format
 msgid "Your localization baseline is ready for review."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5475
-#: lib/glossia_web/live/dashboard_live.ex:6930
+#: lib/glossia_web/live/dashboard_live.ex:5995
+#: lib/glossia_web/live/dashboard_live.ex:7450
 #, elixir-autogen, elixir-format
 msgid "Pull request unavailable"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6237
+#: lib/glossia_web/live/dashboard_live.ex:6757
 #, elixir-autogen, elixir-format
 msgid "Setup brief sent to the agent."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:5477
-#: lib/glossia_web/live/dashboard_live.ex:6932
+#: lib/glossia_web/live/dashboard_live.ex:5997
+#: lib/glossia_web/live/dashboard_live.ex:7452
 #, elixir-autogen, elixir-format
 msgid "Setup finished without a pull request link. Check setup events for details."
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6240
+#: lib/glossia_web/live/dashboard_live.ex:6760
 #, elixir-autogen, elixir-format
 msgid "View prompt"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:6877
+#: lib/glossia_web/live/dashboard_live.ex:7397
 #, elixir-autogen, elixir-format
 msgid "Building a minimal GLOSSIA.md baseline that your team can reuse."
 msgstr ""
@@ -3642,4 +3667,214 @@ msgstr ""
 #: lib/glossia_web/controllers/page_html/home.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "The language OS for your organization"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10308
+#, elixir-autogen, elixir-format
+msgid "Add entry"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10395
+#, elixir-autogen, elixir-format
+msgid "Add terminology entries to this kit."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10368
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this entry?"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10407
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this kit? This action cannot be undone."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2452
+#, elixir-autogen, elixir-format
+msgid "Could not delete entry."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2328
+#, elixir-autogen, elixir-format
+msgid "Could not delete kit."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2467
+#, elixir-autogen, elixir-format
+msgid "Could not star kit."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2481
+#, elixir-autogen, elixir-format
+msgid "Could not unstar kit."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10201
+#, elixir-autogen, elixir-format
+msgid "Create a kit to bundle translation terminology for sharing."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10371
+#, elixir-autogen, elixir-format
+msgid "Delete"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10411
+#, elixir-autogen, elixir-format
+msgid "Delete kit"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:843
+#: lib/glossia_web/live/dashboard_live.ex:10302
+#, elixir-autogen, elixir-format
+msgid "Edit"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:823
+#, elixir-autogen, elixir-format
+msgid "Edit %{name}"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10536
+#, elixir-autogen, elixir-format
+msgid "Edit entry"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10424
+#, elixir-autogen, elixir-format
+msgid "Edit kit"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2380
+#, elixir-autogen, elixir-format
+msgid "Entry added."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2449
+#, elixir-autogen, elixir-format
+msgid "Entry deleted."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2416
+#, elixir-autogen, elixir-format
+msgid "Entry updated."
+msgstr ""
+
+#: lib/glossia_web/controllers/page_html/home.html.heex:6
+#, elixir-autogen, elixir-format
+msgid "Glossia captures your linguistic preferences in one place so linguists and teams can shape how your organization speaks across every language and surface."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2268
+#, elixir-autogen, elixir-format
+msgid "Kit created."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2324
+#, elixir-autogen, elixir-format
+msgid "Kit deleted."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10214
+#, elixir-autogen, elixir-format
+msgid "Kit details"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2296
+#, elixir-autogen, elixir-format
+msgid "Kit updated."
+msgstr ""
+
+#: lib/glossia_web/components/layouts/platform.html.heex:277
+#: lib/glossia_web/live/dashboard_live.ex:750
+#: lib/glossia_web/live/dashboard_live.ex:755
+#: lib/glossia_web/live/dashboard_live.ex:780
+#: lib/glossia_web/live/dashboard_live.ex:805
+#: lib/glossia_web/live/dashboard_live.ex:841
+#: lib/glossia_web/live/dashboard_live.ex:877
+#: lib/glossia_web/live/dashboard_live.ex:931
+#: lib/glossia_web/live/dashboard_live.ex:3547
+#: lib/glossia_web/live/dashboard_live.ex:10143
+#, elixir-autogen, elixir-format
+msgid "Kits"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:860
+#: lib/glossia_web/live/dashboard_live.ex:879
+#: lib/glossia_web/live/dashboard_live.ex:10464
+#, elixir-autogen, elixir-format
+msgid "New entry"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:764
+#: lib/glossia_web/live/dashboard_live.ex:781
+#: lib/glossia_web/live/dashboard_live.ex:10149
+#, elixir-autogen, elixir-format
+msgid "New kit"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:3560
+#, elixir-autogen, elixir-format
+msgid "No description"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10394
+#, elixir-autogen, elixir-format
+msgid "No entries yet"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10200
+#, elixir-autogen, elixir-format
+msgid "No kits yet"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10241
+#: lib/glossia_web/live/dashboard_live.ex:10324
+#: lib/glossia_web/live/dashboard_live.ex:10440
+#, elixir-autogen, elixir-format
+msgid "Private"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10241
+#: lib/glossia_web/live/dashboard_live.ex:10440
+#, elixir-autogen, elixir-format
+msgid "Public"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10144
+#, elixir-autogen, elixir-format
+msgid "Shareable translation terminology bundles."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10168
+#, elixir-autogen, elixir-format
+msgid "Source"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10234
+#: lib/glossia_web/live/dashboard_live.ex:10434
+#, elixir-autogen, elixir-format
+msgid "Source language"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10468
+#: lib/glossia_web/live/dashboard_live.ex:10537
+#, elixir-autogen, elixir-format
+msgid "Source term"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10179
+#, elixir-autogen, elixir-format
+msgid "Stars"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10171
+#, elixir-autogen, elixir-format
+msgid "Targets"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10498
+#: lib/glossia_web/live/dashboard_live.ex:10567
+#, elixir-autogen, elixir-format
+msgid "Usage note"
 msgstr ""

--- a/app/priv/gettext/default.pot
+++ b/app/priv/gettext/default.pot
@@ -1163,6 +1163,7 @@ msgid "Showing %{first}-%{last} of %{total}"
 msgstr ""
 
 #: lib/glossia_web/live/dashboard_live.ex:4770
+#: lib/glossia_web/live/dashboard_live.ex:10308
 #, elixir-autogen, elixir-format
 msgid "Add term"
 msgstr ""
@@ -1238,7 +1239,10 @@ msgstr ""
 msgid "Invitation not found."
 msgstr ""
 
+#: lib/glossia_web/live/dashboard_live.ex:860
+#: lib/glossia_web/live/dashboard_live.ex:879
 #: lib/glossia_web/live/dashboard_live.ex:4597
+#: lib/glossia_web/live/dashboard_live.ex:10464
 #, elixir-autogen, elixir-format
 msgid "New term"
 msgstr ""
@@ -3669,29 +3673,9 @@ msgstr ""
 msgid "The language OS for your organization"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:10308
-#, elixir-autogen, elixir-format
-msgid "Add entry"
-msgstr ""
-
-#: lib/glossia_web/live/dashboard_live.ex:10395
-#, elixir-autogen, elixir-format
-msgid "Add terminology entries to this kit."
-msgstr ""
-
-#: lib/glossia_web/live/dashboard_live.ex:10368
-#, elixir-autogen, elixir-format
-msgid "Are you sure you want to delete this entry?"
-msgstr ""
-
 #: lib/glossia_web/live/dashboard_live.ex:10407
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete this kit? This action cannot be undone."
-msgstr ""
-
-#: lib/glossia_web/live/dashboard_live.ex:2452
-#, elixir-autogen, elixir-format
-msgid "Could not delete entry."
 msgstr ""
 
 #: lib/glossia_web/live/dashboard_live.ex:2328
@@ -3735,29 +3719,9 @@ msgstr ""
 msgid "Edit %{name}"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:10536
-#, elixir-autogen, elixir-format
-msgid "Edit entry"
-msgstr ""
-
 #: lib/glossia_web/live/dashboard_live.ex:10424
 #, elixir-autogen, elixir-format
 msgid "Edit kit"
-msgstr ""
-
-#: lib/glossia_web/live/dashboard_live.ex:2380
-#, elixir-autogen, elixir-format
-msgid "Entry added."
-msgstr ""
-
-#: lib/glossia_web/live/dashboard_live.ex:2449
-#, elixir-autogen, elixir-format
-msgid "Entry deleted."
-msgstr ""
-
-#: lib/glossia_web/live/dashboard_live.ex:2416
-#, elixir-autogen, elixir-format
-msgid "Entry updated."
 msgstr ""
 
 #: lib/glossia_web/controllers/page_html/home.html.heex:6
@@ -3799,13 +3763,6 @@ msgstr ""
 msgid "Kits"
 msgstr ""
 
-#: lib/glossia_web/live/dashboard_live.ex:860
-#: lib/glossia_web/live/dashboard_live.ex:879
-#: lib/glossia_web/live/dashboard_live.ex:10464
-#, elixir-autogen, elixir-format
-msgid "New entry"
-msgstr ""
-
 #: lib/glossia_web/live/dashboard_live.ex:764
 #: lib/glossia_web/live/dashboard_live.ex:781
 #: lib/glossia_web/live/dashboard_live.ex:10149
@@ -3816,11 +3773,6 @@ msgstr ""
 #: lib/glossia_web/live/dashboard_live.ex:3560
 #, elixir-autogen, elixir-format
 msgid "No description"
-msgstr ""
-
-#: lib/glossia_web/live/dashboard_live.ex:10394
-#, elixir-autogen, elixir-format
-msgid "No entries yet"
 msgstr ""
 
 #: lib/glossia_web/live/dashboard_live.ex:10200
@@ -3877,4 +3829,44 @@ msgstr ""
 #: lib/glossia_web/live/dashboard_live.ex:10567
 #, elixir-autogen, elixir-format
 msgid "Usage note"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10395
+#, elixir-autogen, elixir-format
+msgid "Add terms to this kit."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10368
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this term?"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2452
+#, elixir-autogen, elixir-format
+msgid "Could not delete term."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10536
+#, elixir-autogen, elixir-format
+msgid "Edit term"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:10394
+#, elixir-autogen, elixir-format
+msgid "No terms yet"
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2380
+#, elixir-autogen, elixir-format
+msgid "Term added."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2449
+#, elixir-autogen, elixir-format
+msgid "Term deleted."
+msgstr ""
+
+#: lib/glossia_web/live/dashboard_live.ex:2416
+#, elixir-autogen, elixir-format
+msgid "Term updated."
 msgstr ""

--- a/app/priv/repo/migrations/20260301192212_create_kits.exs
+++ b/app/priv/repo/migrations/20260301192212_create_kits.exs
@@ -1,0 +1,69 @@
+defmodule Glossia.Repo.Migrations.CreateKits do
+  use Ecto.Migration
+
+  def change do
+    create table(:kits, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :account_id, references(:accounts, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :created_by_id, references(:users, type: :binary_id, on_delete: :nilify_all)
+      add :handle, :string, null: false
+      add :name, :string, null: false
+      add :description, :text
+      add :source_language, :string, null: false
+      add :target_languages, {:array, :string}, default: [], null: false
+      add :domain_tags, {:array, :string}, default: [], null: false
+      add :visibility, :string, default: "public", null: false
+      add :stars_count, :integer, default: 0, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:kits, [:account_id, :handle])
+    create index(:kits, [:account_id])
+    create index(:kits, [:visibility])
+
+    create table(:kit_entries, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :kit_id, references(:kits, type: :binary_id, on_delete: :delete_all), null: false
+      add :source_term, :string, null: false
+      add :definition, :text
+      add :tags, {:array, :string}, default: [], null: false
+
+      timestamps()
+    end
+
+    create unique_index(:kit_entries, [:kit_id, :source_term])
+    create index(:kit_entries, [:kit_id])
+
+    create table(:kit_entry_translations, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :kit_entry_id, references(:kit_entries, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :language, :string, null: false
+      add :translated_term, :string, null: false
+      add :usage_note, :text
+
+      timestamps()
+    end
+
+    create unique_index(:kit_entry_translations, [:kit_entry_id, :language])
+    create index(:kit_entry_translations, [:kit_entry_id])
+
+    create table(:kit_stars, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :kit_id, references(:kits, type: :binary_id, on_delete: :delete_all), null: false
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+
+      timestamps(updated_at: false)
+    end
+
+    create unique_index(:kit_stars, [:kit_id, :user_id])
+    create index(:kit_stars, [:kit_id])
+    create index(:kit_stars, [:user_id])
+  end
+end

--- a/app/priv/repo/migrations/20260301200431_remove_kit_stars_count.exs
+++ b/app/priv/repo/migrations/20260301200431_remove_kit_stars_count.exs
@@ -1,0 +1,9 @@
+defmodule Glossia.Repo.Migrations.RemoveKitStarsCount do
+  use Ecto.Migration
+
+  def change do
+    alter table(:kits) do
+      remove :stars_count, :integer, default: 0, null: false
+    end
+  end
+end

--- a/app/priv/repo/migrations/20260302075538_rename_kit_entries_to_kit_terminologies.exs
+++ b/app/priv/repo/migrations/20260302075538_rename_kit_entries_to_kit_terminologies.exs
@@ -1,0 +1,11 @@
+defmodule Glossia.Repo.Migrations.RenameKitEntriesToKitTerms do
+  use Ecto.Migration
+
+  def change do
+    rename table(:kit_entries), to: table(:kit_terms)
+    rename table(:kit_entry_translations), to: table(:kit_term_translations)
+
+    # Rename foreign key column in kit_term_translations
+    rename table(:kit_term_translations), :kit_entry_id, to: :kit_term_id
+  end
+end

--- a/app/priv/repo/seeds.exs
+++ b/app/priv/repo/seeds.exs
@@ -26,6 +26,8 @@ defmodule Glossia.Seeds do
   alias Glossia.DeveloperTokens
   alias Glossia.Github.Installations
   alias Glossia.Glossaries
+  alias Glossia.Kits
+  alias Glossia.Kits.Kit
   alias Glossia.OAuth.FirstPartyClient
   alias Glossia.Organizations
   alias Glossia.Projects
@@ -487,6 +489,65 @@ defmodule Glossia.Seeds do
         }
       )
 
+    # ── Kits ──
+    ensure_kit!(dev.account, dev,
+      handle: "medical-terms",
+      name: "Medical Terminology",
+      description: "Standard medical terminology translations for healthcare content.",
+      source_language: "en",
+      target_languages: ["es", "de", "ja"],
+      domain_tags: ["healthcare", "medical"],
+      visibility: "public",
+      entries: [
+        %{
+          source_term: "diagnosis",
+          definition: "The identification of the nature and cause of a certain phenomenon.",
+          tags: ["clinical"],
+          translations: [
+            %{
+              "language" => "es",
+              "translated_term" => "diagnostico",
+              "usage_note" => "Use with accent: diagnostico"
+            },
+            %{"language" => "de", "translated_term" => "Diagnose"},
+            %{"language" => "ja", "translated_term" => "\u8A3A\u65AD"}
+          ]
+        },
+        %{
+          source_term: "prescription",
+          definition:
+            "An instruction written by a medical practitioner for medicine to be dispensed.",
+          tags: ["pharmacy"],
+          translations: [
+            %{"language" => "es", "translated_term" => "receta"},
+            %{"language" => "de", "translated_term" => "Rezept"},
+            %{"language" => "ja", "translated_term" => "\u51E6\u65B9\u7B8B"}
+          ]
+        }
+      ]
+    )
+
+    ensure_kit!(acme.account, dev,
+      handle: "internal-glossary",
+      name: "Internal Glossary",
+      description: "Private terminology for Acme Industries internal docs.",
+      source_language: "en",
+      target_languages: ["es-MX", "pt-BR"],
+      domain_tags: ["internal"],
+      visibility: "private",
+      entries: [
+        %{
+          source_term: "workspace",
+          definition: "A logical container for projects within the Acme platform.",
+          tags: ["product"],
+          translations: [
+            %{"language" => "es-MX", "translated_term" => "espacio de trabajo"},
+            %{"language" => "pt-BR", "translated_term" => "espaco de trabalho"}
+          ]
+        }
+      ]
+    )
+
     ticket3 =
       ensure_discussion!(dev.account, dev,
         title: "OAuth redirect URI validation too strict",
@@ -795,6 +856,51 @@ defmodule Glossia.Seeds do
       else
         ticket
       end
+    end
+  end
+
+  # ----------------------------------------------------------------------------
+  # Kits
+  # ----------------------------------------------------------------------------
+
+  defp ensure_kit!(%Account{} = account, %User{} = user, opts) do
+    handle = Keyword.fetch!(opts, :handle)
+
+    existing =
+      Repo.one(
+        from k in Kit,
+          where: k.account_id == ^account.id and k.handle == ^handle
+      )
+
+    if existing do
+      existing
+    else
+      {:ok, kit} =
+        Kits.create_kit(account, user, %{
+          "handle" => handle,
+          "name" => Keyword.fetch!(opts, :name),
+          "description" => Keyword.get(opts, :description, ""),
+          "source_language" => Keyword.fetch!(opts, :source_language),
+          "target_languages" => Keyword.get(opts, :target_languages, []),
+          "domain_tags" => Keyword.get(opts, :domain_tags, []),
+          "visibility" => Keyword.get(opts, :visibility, "public")
+        })
+
+      entries = Keyword.get(opts, :entries, [])
+
+      for entry_attrs <- entries do
+        translations = Map.get(entry_attrs, :translations, [])
+
+        {:ok, _entry} =
+          Kits.add_entry(kit, %{
+            "source_term" => entry_attrs.source_term,
+            "definition" => Map.get(entry_attrs, :definition, ""),
+            "tags" => Map.get(entry_attrs, :tags, []),
+            "translations" => translations
+          })
+      end
+
+      kit
     end
   end
 

--- a/app/priv/repo/seeds.exs
+++ b/app/priv/repo/seeds.exs
@@ -498,7 +498,7 @@ defmodule Glossia.Seeds do
       target_languages: ["es", "de", "ja"],
       domain_tags: ["healthcare", "medical"],
       visibility: "public",
-      entries: [
+      terms: [
         %{
           source_term: "diagnosis",
           definition: "The identification of the nature and cause of a certain phenomenon.",
@@ -535,7 +535,7 @@ defmodule Glossia.Seeds do
       target_languages: ["es-MX", "pt-BR"],
       domain_tags: ["internal"],
       visibility: "private",
-      entries: [
+      terms: [
         %{
           source_term: "workspace",
           definition: "A logical container for projects within the Acme platform.",
@@ -886,16 +886,16 @@ defmodule Glossia.Seeds do
           "visibility" => Keyword.get(opts, :visibility, "public")
         })
 
-      entries = Keyword.get(opts, :entries, [])
+      terms = Keyword.get(opts, :terms, [])
 
-      for entry_attrs <- entries do
-        translations = Map.get(entry_attrs, :translations, [])
+      for term_attrs <- terms do
+        translations = Map.get(term_attrs, :translations, [])
 
-        {:ok, _entry} =
-          Kits.add_entry(kit, %{
-            "source_term" => entry_attrs.source_term,
-            "definition" => Map.get(entry_attrs, :definition, ""),
-            "tags" => Map.get(entry_attrs, :tags, []),
+        {:ok, _term} =
+          Kits.add_term(kit, %{
+            "source_term" => term_attrs.source_term,
+            "definition" => Map.get(term_attrs, :definition, ""),
+            "tags" => Map.get(term_attrs, :tags, []),
             "translations" => translations
           })
       end


### PR DESCRIPTION
## Summary

Adds Kits as a new feature for linguists to create, curate, and share themed bundles of translation terminology. Each kit contains glossary-style entries with per-language translations. Users can star public kits, which also appear on account profile pages.

The implementation spans all layers: database (4 tables with migration), context module with OpenTelemetry tracing, LetMe authorization, full dashboard UI (list, create, edit, show pages for kits and entries, star/unstar), REST API endpoints, MCP tools, idempotent seeds, and a changelog entry.

All 147 existing tests pass, migration applies cleanly, and seeds run without errors.

## Test plan

- [ ] Run `cd app && mix ecto.migrate` -- migration applies cleanly
- [ ] Run `cd app && mix precommit` -- all checks pass
- [ ] Run `cd app && mix run priv/repo/seeds.exs` -- seeds run idempotently
- [ ] Navigate to `/:handle/-/kits`, create a kit, add entries with translations
- [ ] Star/unstar a kit, verify counter updates
- [ ] Check public kits appear on account profile pages
- [ ] Test REST API: `GET /api/:handle/kits`, `POST /api/:handle/kits`
- [ ] Test MCP tools: `list_kits`, `get_kit`