### PR TITLE
fix(cli): avoid installing all mise tools in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,8 @@ jobs:
 
       - name: Set up mise
         uses: jdx/mise-action@v2
-
-      - name: Install mise tools
-        run: mise install git-cliff
+        with:
+          install_args: git-cliff
 
       - name: Detect releasable changes
         id: detect
@@ -96,9 +95,8 @@ jobs:
 
       - name: Set up mise
         uses: jdx/mise-action@v2
-
-      - name: Install mise tools
-        run: mise install git-cliff
+        with:
+          install_args: git-cliff
 
       - name: Generate CHANGELOG
         run: |

--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,6 @@ hcloud = "latest"
 kubectl = "latest"
 helm = "3"
 op = "latest"
-"gem:kamal" = "2.9.0"
 ruby = "3.4.7"
 git-cliff = "2.10.0"
 


### PR DESCRIPTION
The release workflow uses `jdx/mise-action@v2`, which runs `mise install` by default. Because this repository's `mise.toml` includes the full development toolchain, the release job spends its setup phase installing unrelated tools before it ever reaches `mise install git-cliff`.

This keeps the git-cliff version sourced from `mise.toml` while disabling the action's broad auto-install behavior.